### PR TITLE
GuideEnvironment (WIP)

### DIFF
--- a/modules/core/shared/src/main/scala/gem/GuideEnvironment.scala
+++ b/modules/core/shared/src/main/scala/gem/GuideEnvironment.scala
@@ -3,11 +3,69 @@
 
 package gem
 
-import gem.util.Zipper
+import cats._
+import cats.implicits._
 
-final case class GuideEnvironment[G](auto: Option[G], manual: Either[List[G], Zipper[G]]) {
+sealed trait GuideEnvironment extends Product with Serializable
 
-  def selected: Option[G] =
-    manual.fold(_ => auto, z => Some(z.focus))
+object GuideEnvironment {
+
+  final case class Flamingos2(options: GuideOptions[GuideGroup.Flamingos2]) extends GuideEnvironment
+  final case class GmosNorth(options: GuideOptions[GuideGroup.GmosNorth ])  extends GuideEnvironment
+  final case class GmosSouth(options: GuideOptions[GuideGroup.GmosSouth ])  extends GuideEnvironment
+
+  // placeholder until the other cases are defined
+  case object NoGuiding extends GuideEnvironment
+
+  object Flamingos2 {
+    val empty: Flamingos2 =
+      Flamingos2(GuideOptions.empty[GuideGroup.Flamingos2])
+
+    def typed(o: Option[GuideEnvironment]): Flamingos2 =
+      o match {
+        case Some(e @ Flamingos2(_)) => e
+        case _                       => empty
+      }
+
+    implicit val EqFlamingos2: Eq[Flamingos2] =
+      Eq.instance { (a, b) => a.options  === b.options }
+  }
+
+  object GmosNorth {
+    val empty: GmosNorth =
+      GmosNorth(GuideOptions.empty[GuideGroup.GmosNorth])
+
+    def typed(o: Option[GuideEnvironment]): GmosNorth =
+      o match {
+        case Some(e @ GmosNorth(_)) => e
+        case _                      => empty
+      }
+
+    implicit val EqGmosNorth: Eq[GmosNorth] =
+      Eq.instance { (a, b) => a.options  === b.options }
+  }
+
+  object GmosSouth {
+    val empty: GmosSouth =
+      GmosSouth(GuideOptions.empty[GuideGroup.GmosSouth])
+
+    def typed(o: Option[GuideEnvironment]): GmosSouth =
+      o match {
+        case Some(e @ GmosSouth(_)) => e
+        case _                      => empty
+      }
+
+    implicit val EqGmosSouth: Eq[GmosSouth] =
+      Eq.instance { (a, b) => a.options  === b.options }
+  }
+
+  implicit val EqGuideEnvironment: Eq[GuideEnvironment] =
+    Eq.instance {
+      case (a: Flamingos2, b: Flamingos2) => a === b
+      case (a: GmosNorth,  b: GmosNorth ) => a === b
+      case (a: GmosSouth,  b: GmosSouth ) => a === b
+      case (NoGuiding,     NoGuiding    ) => true
+      case _                              => false
+    }
 
 }

--- a/modules/core/shared/src/main/scala/gem/GuideEnvironment.scala
+++ b/modules/core/shared/src/main/scala/gem/GuideEnvironment.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.util.Zipper
+
+final case class GuideEnvironment[G](auto: Option[G], manual: Either[List[G], Zipper[G]]) {
+
+  def selected: Option[G] =
+    manual.fold(_ => auto, z => Some(z.focus))
+
+}

--- a/modules/core/shared/src/main/scala/gem/GuideGroup.scala
+++ b/modules/core/shared/src/main/scala/gem/GuideGroup.scala
@@ -5,15 +5,15 @@ package gem
 
 import cats._
 import cats.implicits._
-
+import cats.data.NonEmptyList
 import gem.enum.Guider
 
 /**
  * Associates one or more guide probes or guide windows with guide stars.
  */
-sealed trait GuideGroup {
+sealed trait GuideGroup extends Product with Serializable {
 
-  def toMap: Map[Guider, Target]
+  def guideStars: NonEmptyList[(Guider, Target)]
 
 }
 
@@ -29,68 +29,95 @@ object GuideGroup {
   }
 
   /**
-   * Guide "group" for the majority of cases where there is a single guide star.
-   *
-   * @param guider guide probe or guide window
-   * @param target guide star tracked by the guider
+   * Guide "group" supertype for the majority of cases where there is a single
+   * guide star.
    */
-  sealed abstract class SingleGuiderGroup(val guider: Guider, target: Target) extends GuideGroup with Product with Serializable {
+  sealed trait SingleGuider extends GuideGroup {
 
-    override val toMap: Map[Guider, Target] =
-      Map(guider -> target)
+    def guider: Guider
+    def target: Target
+
+    override val guideStars: NonEmptyList[(Guider, Target)] =
+      NonEmptyList.one(guider -> target)
 
   }
+
+  sealed trait Flamingos2 extends SingleGuider
 
   object Flamingos2 {
-    final case class OI(target: Target) extends SingleGuiderGroup(Guider.F2OI, target)
-    final case class P1(target: Target) extends SingleGuiderGroup(Guider.P1GS, target)
-    final case class P2(target: Target) extends SingleGuiderGroup(Guider.P2GS, target)
+
+    final case class OI(target: Target) extends Flamingos2 {
+      override val guider: Guider = Guider.F2OI
+    }
+
+    final case class P1(target: Target) extends Flamingos2 {
+      override val guider: Guider = Guider.P1GS
+    }
+
+    final case class P2(target: Target) extends Flamingos2 {
+      override val guider: Guider = Guider.P2GS
+    }
+
+    implicit val EqFlamingos2: Eq[Flamingos2] =
+      Eq.instance {
+        case (OI(a), OI(b)) => a === b
+        case (P1(a), P1(b)) => a === b
+        case (P2(a), P2(b)) => a === b
+        case _              => false
+      }
   }
+
+  sealed trait GmosNorth extends SingleGuider
 
   object GmosNorth {
-    final case class OI(target: Target) extends SingleGuiderGroup(Guider.GmosNOI, target)
-    final case class P1(target: Target) extends SingleGuiderGroup(Guider.P1GN,    target)
-    final case class P2(target: Target) extends SingleGuiderGroup(Guider.P2GN,    target)
+
+    final case class OI(target: Target) extends GmosNorth {
+      override val guider: Guider = Guider.GmosNOI
+    }
+
+    final case class P1(target: Target) extends GmosNorth {
+      override val guider: Guider = Guider.P1GS
+    }
+
+    final case class P2(target: Target) extends GmosNorth {
+      override val guider: Guider = Guider.P2GS
+    }
+
+    implicit val EqGmosNorth: Eq[GmosNorth] =
+      Eq.instance {
+        case (OI(a), OI(b)) => a === b
+        case (P1(a), P1(b)) => a === b
+        case (P2(a), P2(b)) => a === b
+        case _              => false
+      }
+
   }
 
+  sealed trait GmosSouth extends SingleGuider
+
   object GmosSouth {
-    final case class OI(target: Target) extends SingleGuiderGroup(Guider.GmosSOI, target)
-    final case class P1(target: Target) extends SingleGuiderGroup(Guider.P1GS,    target)
-    final case class P2(target: Target) extends SingleGuiderGroup(Guider.P2GS,    target)
+
+    final case class OI(target: Target) extends GmosSouth {
+      override val guider: Guider = Guider.GmosSOI
+    }
+
+    final case class P1(target: Target) extends GmosSouth {
+      override val guider: Guider = Guider.P1GS
+    }
+
+    final case class P2(target: Target) extends GmosSouth {
+      override val guider: Guider = Guider.P2GS
+    }
+
+    implicit val EqGmosSouth: Eq[GmosSouth] =
+      Eq.instance {
+        case (OI(a), OI(b)) => a === b
+        case (P1(a), P1(b)) => a === b
+        case (P2(a), P2(b)) => a === b
+        case _              => false
+      }
+
+
   }
 
 }
-
-//sealed trait GmosSouthGuideGroup
-//
-//object GmosSouthGuideGroup {
-//  final case class Oi(star: Target) extends GmosSouthGuideGroup
-//  final case class P1(star: Target) extends GmosSouthGuideGroup
-//  final case class P2(star: Target) extends GmosSouthGuideGroup
-//}
-//
-//sealed trait OiGuideGroupType
-//
-//object OiGuideGroupType {
-//  case object Oi extends OiGuideGroupType
-//  case object P1 extends OiGuideGroupType
-//  case object P2 extends OiGuideGroupType
-//}
-//
-//final case class OiGuideGroup(s: Target, t: OiGuideGroupType)
-//
-//sealed trait GsaoiGuideGroup
-//
-//object GsaoiGuideGroup {
-//  final case class Gems(cwfs1: Option[Target], cwfs2: Option[Target], cwfs3: Target) extends GsaoiGuideGroup
-//  final case class P1(star: Target)                                                  extends GsaoiGuideGroup
-//}
-//
-//sealed abstract class GuideEnvironment[G](auto: Option[G], manual: Either[List[G], Zipper[G]]) {
-//
-//  def selected: Option[G] =
-//    manual.fold(_ => auto, Some(_.focus))
-//
-//}
-//
-//final case class GmosSouthGuideEnvironment(e: GuideEnvironment[OiGuideGroup])

--- a/modules/core/shared/src/main/scala/gem/GuideGroup.scala
+++ b/modules/core/shared/src/main/scala/gem/GuideGroup.scala
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import cats.implicits._
+
+import gem.enum.Guider
+
+/**
+ * Associates one or more guide probes or guide windows with guide stars.
+ */
+sealed trait GuideGroup {
+
+  def toMap: Map[Guider, Target]
+
+}
+
+object GuideGroup {
+
+  /** Group identifier. */
+  final case class Id(toInt: Int) extends AnyVal
+
+  object Id {
+    /** Ids ordered by wrapped integer value. */
+    implicit val IdOrder: Order[Id] =
+      Order.by(_.toInt)
+  }
+
+  /**
+   * Guide "group" for the majority of cases where there is a single guide star.
+   *
+   * @param guider guide probe or guide window
+   * @param target guide star tracked by the guider
+   */
+  sealed abstract class SingleGuiderGroup(val guider: Guider, target: Target) extends GuideGroup with Product with Serializable {
+
+    override val toMap: Map[Guider, Target] =
+      Map(guider -> target)
+
+  }
+
+  object Flamingos2 {
+    final case class OI(target: Target) extends SingleGuiderGroup(Guider.F2OI, target)
+    final case class P1(target: Target) extends SingleGuiderGroup(Guider.P1GS, target)
+    final case class P2(target: Target) extends SingleGuiderGroup(Guider.P2GS, target)
+  }
+
+  object GmosNorth {
+    final case class OI(target: Target) extends SingleGuiderGroup(Guider.GmosNOI, target)
+    final case class P1(target: Target) extends SingleGuiderGroup(Guider.P1GN,    target)
+    final case class P2(target: Target) extends SingleGuiderGroup(Guider.P2GN,    target)
+  }
+
+  object GmosSouth {
+    final case class OI(target: Target) extends SingleGuiderGroup(Guider.GmosSOI, target)
+    final case class P1(target: Target) extends SingleGuiderGroup(Guider.P1GS,    target)
+    final case class P2(target: Target) extends SingleGuiderGroup(Guider.P2GS,    target)
+  }
+
+}
+
+//sealed trait GmosSouthGuideGroup
+//
+//object GmosSouthGuideGroup {
+//  final case class Oi(star: Target) extends GmosSouthGuideGroup
+//  final case class P1(star: Target) extends GmosSouthGuideGroup
+//  final case class P2(star: Target) extends GmosSouthGuideGroup
+//}
+//
+//sealed trait OiGuideGroupType
+//
+//object OiGuideGroupType {
+//  case object Oi extends OiGuideGroupType
+//  case object P1 extends OiGuideGroupType
+//  case object P2 extends OiGuideGroupType
+//}
+//
+//final case class OiGuideGroup(s: Target, t: OiGuideGroupType)
+//
+//sealed trait GsaoiGuideGroup
+//
+//object GsaoiGuideGroup {
+//  final case class Gems(cwfs1: Option[Target], cwfs2: Option[Target], cwfs3: Target) extends GsaoiGuideGroup
+//  final case class P1(star: Target)                                                  extends GsaoiGuideGroup
+//}
+//
+//sealed abstract class GuideEnvironment[G](auto: Option[G], manual: Either[List[G], Zipper[G]]) {
+//
+//  def selected: Option[G] =
+//    manual.fold(_ => auto, Some(_.focus))
+//
+//}
+//
+//final case class GmosSouthGuideEnvironment(e: GuideEnvironment[OiGuideGroup])

--- a/modules/core/shared/src/main/scala/gem/GuideOptions.scala
+++ b/modules/core/shared/src/main/scala/gem/GuideOptions.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import gem.util.Zipper
+
+import cats._
+import cats.implicits._
+
+
+/**
+ * Each observation has a collection of guide options, where each option is a
+ * guide group. One of these options is automatically managed by the auto-guide
+ * star service.  The rest, if any, are manually added by the user.  There can
+ * be zero or one selected groups.  The selection indicates which group will be
+ * used for observing.
+ *
+ * @param auto   automatically managed guide group
+ * @param manual manually added guide groups, where `Left` indicates that none
+ *               of the manual groups is the selected group while `Right`
+ *               indicates that a particular manual group (the zipper focus)
+ *               should be used instead of the auto group
+ *
+ * @tparam G guide group type
+ */
+final case class GuideOptions[G](
+  auto:   Option[G],
+  manual: Either[List[G], Zipper[G]]
+) {
+
+  def all: List[G] = {
+    def ms = manual.fold(identity, _.toList)
+    auto.fold(ms)(_ :: ms)
+  }
+
+  def selected: Option[G] =
+    manual.fold(_ => auto, z => Some(z.focus))
+
+}
+
+object GuideOptions {
+
+  def empty[G]: GuideOptions[G] =
+    GuideOptions(None, Left(Nil))
+
+  implicit val FunctorGuideOptions: Functor[GuideOptions] =
+    new Functor[GuideOptions] {
+      def map[A, B](ga: GuideOptions[A])(f: A => B): GuideOptions[B] =
+        GuideOptions(ga.auto.map(f), ga.manual.bimap(_.map(f), _.map(f)))
+    }
+
+  implicit def EqGuideOptions[G: Eq]: Eq[GuideOptions[G]] =
+    Eq.instance { (a, b) =>
+      (a.auto === b.auto) && (a.manual === b.manual)
+    }
+}

--- a/modules/core/shared/src/main/scala/gem/GuideStar.scala
+++ b/modules/core/shared/src/main/scala/gem/GuideStar.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import cats.implicits._
+
+object GuideStar {
+
+  final case class Id(toInt: Int) extends AnyVal
+
+  object Id {
+    implicit val IdOrder: Order[Id] =
+      Order.by(_.toInt)
+  }
+
+}

--- a/modules/core/shared/src/main/scala/gem/GuideStar.scala
+++ b/modules/core/shared/src/main/scala/gem/GuideStar.scala
@@ -6,6 +6,9 @@ package gem
 import cats._
 import cats.implicits._
 
+/**
+ * Provides a namespace in order to define the guide star id type.
+ */
 object GuideStar {
 
   final case class Id(toInt: Int) extends AnyVal

--- a/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
+++ b/modules/core/shared/src/main/scala/gem/TargetEnvironment.scala
@@ -10,6 +10,7 @@ import scala.collection.immutable.SortedSet
 /** Collection of targets associated with an observation. */
 sealed trait TargetEnvironment {
   def asterism: Option[Asterism]
+  def guideEnvironment: GuideEnvironment
   def userTargets: SortedSet[UserTarget]
   override final def toString =
     s"TargetEnvironment($asterism, $userTargets)"
@@ -17,44 +18,52 @@ sealed trait TargetEnvironment {
 
 object TargetEnvironment {
 
-  def fromAsterism(a: Asterism, u: SortedSet[UserTarget]): TargetEnvironment =
+  def fromAsterism(
+    a: Asterism,
+    g: Option[GuideEnvironment],
+    u: SortedSet[UserTarget]
+  ): TargetEnvironment =
     a match {
-      case a @ Asterism.Phoenix(_)            => Phoenix(Some(a), u)
-      case a @ Asterism.Michelle(_)           => Michelle(Some(a), u)
+      case a @ Asterism.AcqCam(_)             => AcqCam(Some(a), u)
+      case a @ Asterism.Bhros(_)              => Bhros(Some(a), u)
+      case a @ Asterism.Flamingos2(_)         => Flamingos2(Some(a), GuideEnvironment.Flamingos2.typed(g), u)
+      case a @ Asterism.GhostDualTarget(_, _) => Ghost(Some(a), u)
+      case a @ Asterism.GmosN(_)              => GmosN(Some(a), GuideEnvironment.GmosNorth.typed(g), u)
+      case a @ Asterism.GmosS(_)              => GmosS(Some(a), GuideEnvironment.GmosSouth.typed(g), u)
       case a @ Asterism.Gnirs(_)              => Gnirs(Some(a), u)
-      case a @ Asterism.Niri(_)               => Niri(Some(a), u)
-      case a @ Asterism.Trecs(_)              => Trecs(Some(a), u)
-      case a @ Asterism.Nici(_)               => Nici(Some(a), u)
-      case a @ Asterism.Nifs(_)               => Nifs(Some(a), u)
       case a @ Asterism.Gpi(_)                => Gpi(Some(a), u)
       case a @ Asterism.Gsaoi(_)              => Gsaoi(Some(a), u)
-      case a @ Asterism.GmosS(_)              => GmosS(Some(a), u)
-      case a @ Asterism.AcqCam(_)             => AcqCam(Some(a), u)
-      case a @ Asterism.GmosN(_)              => GmosN(Some(a), u)
-      case a @ Asterism.Bhros(_)              => Bhros(Some(a), u)
+      case a @ Asterism.Michelle(_)           => Michelle(Some(a), u)
+      case a @ Asterism.Nici(_)               => Nici(Some(a), u)
+      case a @ Asterism.Nifs(_)               => Nifs(Some(a), u)
+      case a @ Asterism.Niri(_)               => Niri(Some(a), u)
+      case a @ Asterism.Phoenix(_)            => Phoenix(Some(a), u)
+      case a @ Asterism.Trecs(_)              => Trecs(Some(a), u)
       case a @ Asterism.Visitor(_)            => Visitor(Some(a), u)
-      case a @ Asterism.Flamingos2(_)         => Flamingos2(Some(a), u)
-      case a @ Asterism.GhostDualTarget(_, _) => Ghost(Some(a), u)
     }
 
-  def fromInstrument(i: Instrument, ts: SortedSet[UserTarget]): TargetEnvironment =
+  def fromInstrument(
+    i: Instrument,
+    g: Option[GuideEnvironment],
+    u: SortedSet[UserTarget]
+  ): TargetEnvironment =
     i match {
-      case Instrument.Phoenix    => TargetEnvironment.Phoenix(None, ts)
-      case Instrument.Michelle   => TargetEnvironment.Michelle(None, ts)
-      case Instrument.Gnirs      => TargetEnvironment.Gnirs(None, ts)
-      case Instrument.Niri       => TargetEnvironment.Niri(None, ts)
-      case Instrument.Trecs      => TargetEnvironment.Trecs(None, ts)
-      case Instrument.Nici       => TargetEnvironment.Nici(None, ts)
-      case Instrument.Nifs       => TargetEnvironment.Nifs(None, ts)
-      case Instrument.Gpi        => TargetEnvironment.Gpi(None, ts)
-      case Instrument.Gsaoi      => TargetEnvironment.Gsaoi(None, ts)
-      case Instrument.GmosS      => TargetEnvironment.GmosS(None, ts)
-      case Instrument.AcqCam     => TargetEnvironment.AcqCam(None, ts)
-      case Instrument.GmosN      => TargetEnvironment.GmosN(None, ts)
-      case Instrument.Bhros      => TargetEnvironment.Bhros(None, ts)
-      case Instrument.Visitor    => TargetEnvironment.Visitor(None, ts)
-      case Instrument.Flamingos2 => TargetEnvironment.Flamingos2(None, ts)
-      case Instrument.Ghost      => TargetEnvironment.Ghost(None, ts)
+      case Instrument.AcqCam     => AcqCam(None, u)
+      case Instrument.Bhros      => Bhros(None, u)
+      case Instrument.Flamingos2 => Flamingos2(None, GuideEnvironment.Flamingos2.typed(g), u)
+      case Instrument.Ghost      => Ghost(None, u)
+      case Instrument.GmosN      => GmosN(None, GuideEnvironment.GmosNorth.typed(g), u)
+      case Instrument.GmosS      => GmosS(None, GuideEnvironment.GmosSouth.typed(g), u)
+      case Instrument.Gnirs      => Gnirs(None, u)
+      case Instrument.Gpi        => Gpi(None, u)
+      case Instrument.Gsaoi      => Gsaoi(None, u)
+      case Instrument.Michelle   => Michelle(None, u)
+      case Instrument.Nici       => Nici(None, u)
+      case Instrument.Nifs       => Nifs(None, u)
+      case Instrument.Niri       => Niri(None, u)
+      case Instrument.Phoenix    => Phoenix(None, u)
+      case Instrument.Trecs      => Trecs(None, u)
+      case Instrument.Visitor    => Visitor(None, u)
     }
 
   /** Target environment for Phoenix
@@ -63,7 +72,10 @@ object TargetEnvironment {
   final case class Phoenix(
     asterism: Option[Asterism.Phoenix],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Michelle
     * @group Constructors
@@ -71,7 +83,10 @@ object TargetEnvironment {
   final case class Michelle(
     asterism: Option[Asterism.Michelle],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Gnirs
     * @group Constructors
@@ -79,7 +94,10 @@ object TargetEnvironment {
   final case class Gnirs(
     asterism: Option[Asterism.Gnirs],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Niri
     * @group Constructors
@@ -87,7 +105,10 @@ object TargetEnvironment {
   final case class Niri(
     asterism: Option[Asterism.Niri],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Trecs
     * @group Constructors
@@ -95,7 +116,10 @@ object TargetEnvironment {
   final case class Trecs(
     asterism: Option[Asterism.Trecs],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Nici
     * @group Constructors
@@ -103,7 +127,10 @@ object TargetEnvironment {
   final case class Nici(
     asterism: Option[Asterism.Nici],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Nifs
     * @group Constructors
@@ -111,7 +138,10 @@ object TargetEnvironment {
   final case class Nifs(
     asterism: Option[Asterism.Nifs],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Gpi
     * @group Constructors
@@ -119,7 +149,10 @@ object TargetEnvironment {
   final case class Gpi(
     asterism: Option[Asterism.Gpi],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Gsaoi
     * @group Constructors
@@ -127,13 +160,17 @@ object TargetEnvironment {
   final case class Gsaoi(
     asterism: Option[Asterism.Gsaoi],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for GmosS
     * @group Constructors
     */
   final case class GmosS(
     asterism: Option[Asterism.GmosS],
+    guideEnvironment: GuideEnvironment.GmosSouth,
     userTargets: SortedSet[UserTarget]
   ) extends TargetEnvironment
 
@@ -143,13 +180,17 @@ object TargetEnvironment {
   final case class AcqCam(
     asterism: Option[Asterism.AcqCam],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for GmosN
     * @group Constructors
     */
   final case class GmosN(
     asterism: Option[Asterism.GmosN],
+    guideEnvironment: GuideEnvironment.GmosNorth,
     userTargets: SortedSet[UserTarget]
   ) extends TargetEnvironment
 
@@ -159,7 +200,10 @@ object TargetEnvironment {
   final case class Bhros(
     asterism: Option[Asterism.Bhros],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Visitor
     * @group Constructors
@@ -167,13 +211,17 @@ object TargetEnvironment {
   final case class Visitor(
     asterism: Option[Asterism.Visitor],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   /** Target environment for Flamingos2
     * @group Constructors
     */
   final case class Flamingos2(
     asterism: Option[Asterism.Flamingos2],
+    guideEnvironment: GuideEnvironment.Flamingos2,
     userTargets: SortedSet[UserTarget]
   ) extends TargetEnvironment
 
@@ -183,7 +231,10 @@ object TargetEnvironment {
   final case class Ghost(
     asterism: Option[Asterism.GhostDualTarget],
     userTargets: SortedSet[UserTarget]
-  ) extends TargetEnvironment
+  ) extends TargetEnvironment {
+    def guideEnvironment: GuideEnvironment =
+      GuideEnvironment.NoGuiding
+  }
 
   implicit def EqTargetEnvironment: Eq[TargetEnvironment] =
     Eq.fromUniversalEquals

--- a/modules/core/shared/src/main/scala/gem/enum/GuideGroupType.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/GuideGroupType.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for guide group types.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class GuideGroupType(
+  val tag: String
+) extends Product with Serializable
+
+object GuideGroupType {
+
+  /** @group Constructors */ case object Automatic extends GuideGroupType("Automatic")
+  /** @group Constructors */ case object Manual extends GuideGroupType("Manual")
+
+  /** All members of GuideGroupType, in canonical order. */
+  val all: List[GuideGroupType] =
+    List(Automatic, Manual)
+
+  /** Select the member of GuideGroupType with the given tag, if any. */
+  def fromTag(s: String): Option[GuideGroupType] =
+    all.find(_.tag === s)
+
+  /** Select the member of GuideGroupType with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): GuideGroupType =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GuideGroupTypeEnumerated: Enumerated[GuideGroupType] =
+    new Enumerated[GuideGroupType] {
+      def all = GuideGroupType.all
+      def tag(a: GuideGroupType) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/enum/Guider.scala
+++ b/modules/core/shared/src/main/scala/gem/enum/Guider.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package enum
+
+import cats.instances.string._
+import cats.syntax.eq._
+import gem.util.Enumerated
+
+/**
+ * Enumerated type for guider.
+ * @group Enumerations (Generated)
+ */
+sealed abstract class Guider(
+  val tag: String,
+  val instrument: Option[Instrument],
+  val shortName: String,
+  val longName: String
+) extends Product with Serializable
+
+object Guider {
+
+  /** @group Constructors */ case object F2OI extends Guider("F2OI", Some(Instrument.Flamingos2), "F2 OI", "Flamingos2 OIWFS")
+  /** @group Constructors */ case object GmosNOI extends Guider("GmosNOI", Some(Instrument.GmosN), "GMOS-N OI", "GMOS North OIWFS")
+  /** @group Constructors */ case object GmosSOI extends Guider("GmosSOI", Some(Instrument.GmosS), "GMOS-S OI", "GMOS South OIWFS")
+  /** @group Constructors */ case object P1GN extends Guider("P1GN", None, "P1 GN", "PWFS1 North")
+  /** @group Constructors */ case object P2GN extends Guider("P2GN", None, "P2 GN", "PWFS2 North")
+  /** @group Constructors */ case object P1GS extends Guider("P1GS", None, "P1 GS", "PWFS1 South")
+  /** @group Constructors */ case object P2GS extends Guider("P2GS", None, "P2 GS", "PWFS2 South")
+
+  /** All members of Guider, in canonical order. */
+  val all: List[Guider] =
+    List(F2OI, GmosNOI, GmosSOI, P1GN, P2GN, P1GS, P2GS)
+
+  /** Select the member of Guider with the given tag, if any. */
+  def fromTag(s: String): Option[Guider] =
+    all.find(_.tag === s)
+
+  /** Select the member of Guider with the given tag, throwing if absent. */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromTag(s: String): Guider =
+    fromTag(s).getOrElse(throw new NoSuchElementException(s))
+
+  /** @group Typeclass Instances */
+  implicit val GuiderEnumerated: Enumerated[Guider] =
+    new Enumerated[Guider] {
+      def all = Guider.all
+      def tag(a: Guider) = a.tag
+    }
+
+}

--- a/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
@@ -30,6 +30,17 @@ final class TreeMapCompanionOps(val self: TreeMap.type) extends AnyVal {
    */
   def join[A: Ordering, B](ms: List[TreeMap[A, B]]): TreeMap[A, B] =
     ms.foldLeft(TreeMap.empty[A, B]) { case (m0, m1) => m0 ++ m1 }
+
+  /**
+   * Groups a `List[A]` by the given key.  Like traversable `groupBy` but
+   * producing a `TreeMap`
+   */
+  def grouping[K: Ordering, A](as: List[A])(f: A => K): TreeMap[K, List[A]] =
+    as.foldRight(TreeMap.empty[K, List[A]]) { case (a, m) =>
+      val k = f(a)
+      m.updated(k, a :: m.getOrElse(k, List.empty[A]))
+    }
+
 }
 
 trait ToTreeMapCompanionOps {
@@ -54,7 +65,7 @@ final class TreeMapOps[A, B](val self: TreeMap[A, B]) extends AnyVal {
     }
 
   /**
-   *  Merges two maps together according to the supplied function. The function
+   * Merges two maps together according to the supplied function. The function
    * takes an `Ior` with the value from this map and/or the value from that map
    * for each key present in either map.
    *
@@ -67,6 +78,13 @@ final class TreeMapOps[A, B](val self: TreeMap[A, B]) extends AnyVal {
         m.updated(a, f(ior))
       }
     }
+
+  /**
+   * Like `mapValues` but produces a copy in a new `TreeMap` instead of a
+   * `SortedMap` view.
+   */
+  def treeMapValues[C](f: B => C)(implicit ev: Ordering[A]): TreeMap[A, C] =
+    self.foldLeft(TreeMap.empty[A, C]) { case (m, (a, b)) => m.updated(a, f(b)) }
 }
 
 trait ToTreeMapOps {

--- a/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
+++ b/modules/core/shared/src/main/scala/gem/syntax/TreeMap.scala
@@ -10,21 +10,24 @@ import scala.collection.immutable.TreeMap
 
 final class TreeMapCompanionOps(val self: TreeMap.type) extends AnyVal {
 
-  /** Creates a `TreeMap` from a `List[(A, B)]`, provided an `Ordering[A]`
-    * is available.
-    */
+  /**
+   * Creates a `TreeMap` from a `List[(A, B)]`, provided an `Ordering[A]`
+   * is available.
+   */
   def fromList[A: Ordering, B](lst: List[(A, B)]): TreeMap[A, B] =
     TreeMap(lst: _*)
 
-  /** Creates a `TreeMap` from a `Foldable[(A, B)]`, provided an `Ordering[A]`
-    * is available.
-    */
+  /**
+   * Creates a `TreeMap` from a `Foldable[(A, B)]`, provided an `Ordering[A]`
+   * is available.
+   */
   def fromFoldable[F[_], A, B](fab: F[(A, B)])(implicit F: Foldable[F], A: Ordering[A]): TreeMap[A, B] =
     fromList(F.toList(fab))
 
-  /** Combines all the given maps into a single map, where keys common to two or
-    * more maps are the value of the last occurrence in the list.
-    */
+  /**
+   * Combines all the given maps into a single map, where keys common to two or
+   * more maps are the value of the last occurrence in the list.
+   */
   def join[A: Ordering, B](ms: List[TreeMap[A, B]]): TreeMap[A, B] =
     ms.foldLeft(TreeMap.empty[A, B]) { case (m0, m1) => m0 ++ m1 }
 }
@@ -36,26 +39,28 @@ trait ToTreeMapCompanionOps {
 
 final class TreeMapOps[A, B](val self: TreeMap[A, B]) extends AnyVal {
 
-  /** Combines this map with the values of matching keys from `that` map using
-    * supplied function.  Keys that only exist in `that` are ignored, but the
-    * value of keys that exist in this map but not in `that` map are passed to
-    * the function as None.
-    *
-    * @param that the map to combine with this one
-    * @param f function that combines the values
-    */
+  /**
+   * Combines this map with the values of matching keys from `that` map using
+   * supplied function.  Keys that only exist in `that` are ignored, but the
+   * value of keys that exist in this map but not in `that` map are passed to
+   * the function as None.
+   *
+   * @param that the map to combine with this one
+   * @param f function that combines the values
+   */
   def mergeMatchingKeys[C, D](that: Map[A, C])(f: (B, Option[C]) => D)(implicit ev: Ordering[A]): TreeMap[A, D] =
     self.foldLeft(TreeMap.empty[A, D]) { case (m, (a, b)) =>
       m.updated(a, f(b, that.get(a)))
     }
 
-  /** Merges two maps together according to the supplied function. The function
-    * takes an `Ior` with the value from this map and/or the value from that map
-    * for each key present in either map.
-    *
-    * @param that the map to merge with this one
-    * @param f function that combines the values
-    */
+  /**
+   *  Merges two maps together according to the supplied function. The function
+   * takes an `Ior` with the value from this map and/or the value from that map
+   * for each key present in either map.
+   *
+   * @param that the map to merge with this one
+   * @param f function that combines the values
+   */
   def mergeAll[C, D](that: Map[A, C])(f: Ior[B, C] => D)(implicit ev: Ordering[A]): TreeMap[A, D] =
     (self.keySet  ++ that.keySet).foldLeft(TreeMap.empty[A, D]) { (m, a) =>
       Ior.fromOptions(self.get(a), that.get(a)).fold(m) { ior =>

--- a/modules/core/shared/src/main/scala/gem/util/Zipper.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Zipper.scala
@@ -3,12 +3,21 @@
 
 package gem.util
 
+import cats._
+import cats.implicits._
 import cats.data.NonEmptyList
 
 /**
- * A placeholder zipper for now. Stolen from https://github.com/tpolecat/tuco/blob/master/modules/core/src/main/scala/tuco/util/zipper.scala
+ * A placeholder zipper for now. Stolen and modified from
+ * https://github.com/tpolecat/tuco/blob/master/modules/core/src/main/scala/tuco/util/zipper.scala
  */
 final case class Zipper[A](lefts: List[A], focus: A, rights: List[A]) {
+
+  def toList: List[A] =
+    lefts.reverse ++ (focus :: rights)
+
+  def toNel: NonEmptyList[A] =
+    NonEmptyList.fromListUnsafe(toList) // we know the list has at least one element, the focus
 
   def previous: Option[Zipper[A]] =
     lefts match {
@@ -19,12 +28,58 @@ final case class Zipper[A](lefts: List[A], focus: A, rights: List[A]) {
   def next: Option[Zipper[A]] =
     rights match {
       case Nil     => None
-      case a :: as => Some(Zipper(focus :: rights, a, as))
+      case a :: as => Some(Zipper(focus :: lefts, a, as))
     }
 
 }
 
 object Zipper {
-  def single[A](a: A): Zipper[A] = Zipper(Nil, a, Nil)
-  def fromNonEmptyList[A](nel: NonEmptyList[A]): Zipper[A] = Zipper(Nil, nel.head, nel.tail)
+
+  /**
+   * @group Constructors
+   */
+  def single[A](a: A): Zipper[A] =
+    Zipper(Nil, a, Nil)
+
+  /**
+   * @group Constructors
+   */
+  def fromNonEmptyList[A](nel: NonEmptyList[A]): Zipper[A] =
+    Zipper(Nil, nel.head, nel.tail)
+
+  /**
+   * @group Instances
+   */
+  implicit def EqZipper[A: Eq]: Eq[Zipper[A]] =
+    Eq.instance { (za, zb) =>
+      (za.focus === zb.focus)   &&
+        (za.lefts === zb.lefts) &&
+        (za.rights === zb.rights)
+    }
+
+  /**
+   * Applicative defined as Applicative[List] where the focus is the element
+   * produced by applying the focus of Zipper[A => B] to the focus of Zipper[A].
+   *
+   * @group Instances
+   */
+  implicit val ApplicativeZipper: Applicative[Zipper] =
+    new Applicative[Zipper] {
+
+      def pure[A](a: A): Zipper[A] =
+        Zipper(Nil, a, Nil)
+
+      def ap[A, B](zf: Zipper[A => B])(za: Zipper[A]): Zipper[B] = {
+        val as = za.toList
+
+        Zipper(
+          za.lefts.map(zf.focus)  ++ zf.lefts.reverse.flatMap(f => as.map(f)).reverse,
+          zf.focus(za.focus),
+          za.rights.map(zf.focus) ++ zf.rights.flatMap(f => as.map(f))
+        )
+      }
+    }
+
+  // NonEmptyTraverse[Zipper] should be do-able as well.
+
 }

--- a/modules/core/shared/src/main/scala/gem/util/Zipper.scala
+++ b/modules/core/shared/src/main/scala/gem/util/Zipper.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.util
+
+import cats.data.NonEmptyList
+
+/**
+ * A placeholder zipper for now. Stolen from https://github.com/tpolecat/tuco/blob/master/modules/core/src/main/scala/tuco/util/zipper.scala
+ */
+final case class Zipper[A](lefts: List[A], focus: A, rights: List[A]) {
+
+  def previous: Option[Zipper[A]] =
+    lefts match {
+      case Nil     => None
+      case a :: as => Some(Zipper(as, a, focus :: rights))
+    }
+
+  def next: Option[Zipper[A]] =
+    rights match {
+      case Nil     => None
+      case a :: as => Some(Zipper(focus :: rights, a, as))
+    }
+
+}
+
+object Zipper {
+  def single[A](a: A): Zipper[A] = Zipper(Nil, a, Nil)
+  def fromNonEmptyList[A](nel: NonEmptyList[A]): Zipper[A] = Zipper(Nil, nel.head, nel.tail)
+}

--- a/modules/core/shared/src/test/scala/gem/arb/ArbTargetEnvironment.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbTargetEnvironment.scala
@@ -17,12 +17,13 @@ trait ArbTargetEnvironment {
   import ArbEnumerated._
   import ArbUserTarget._
 
+  // TODO: GuideEnvironment
   def genTargetEnvironment(i: Instrument): Gen[TargetEnvironment] =
     for {
       a <- frequency((9, genAsterism(i).map(Option(_))), (1, const(Option.empty[Asterism])))
       n <- choose(0, 10)
       u <- listOfN(n, arbitrary[UserTarget]).map(us => TreeSet.fromList(us))
-    } yield a.fold(TargetEnvironment.fromInstrument(i, u))(TargetEnvironment.fromAsterism(_, u))
+    } yield a.fold(TargetEnvironment.fromInstrument(i, None, u))(TargetEnvironment.fromAsterism(_, None, u))
 
   implicit val arbTargetEnvironment: Arbitrary[TargetEnvironment] =
     Arbitrary {
@@ -32,6 +33,7 @@ trait ArbTargetEnvironment {
       } yield e
     }
 
+  // TODO: GuideEnvironment
   implicit val cogTargetEnvironment: Cogen[TargetEnvironment] =
     Cogen[(Option[Asterism], List[UserTarget])].contramap(e => (e.asterism, e.userTargets.toList))
 

--- a/modules/core/shared/src/test/scala/gem/arb/ArbZipper.scala
+++ b/modules/core/shared/src/test/scala/gem/arb/ArbZipper.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.arb
+
+import gem.util.Zipper
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
+
+
+trait ArbZipper {
+
+  implicit def arbZipper[A: Arbitrary]: Arbitrary[Zipper[A]] =
+    Arbitrary {
+      for {
+        l <- arbitrary[List[A]]
+        f <- arbitrary[A]
+        r <- arbitrary[List[A]]
+      } yield Zipper(l, f, r)
+    }
+
+  implicit def cogZipper[A: Cogen]: Cogen[Zipper[A]] =
+    Cogen[List[A]].contramap(_.toList)
+
+}
+
+object ArbZipper extends ArbZipper

--- a/modules/core/shared/src/test/scala/gem/util/ZipperSpec.scala
+++ b/modules/core/shared/src/test/scala/gem/util/ZipperSpec.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.util
+
+import gem.arb._
+
+import cats.kernel.laws.discipline._
+import cats.laws.discipline._
+import cats.tests.CatsSuite
+
+
+final class ZipperSpec extends CatsSuite {
+
+  import ArbZipper._
+
+  checkAll("Eq",          EqTests[Zipper[Byte]].eqv)
+  checkAll("Applicative", ApplicativeTests[Zipper].applicative[Byte, Byte, Byte])
+
+}

--- a/modules/db/src/main/scala/gem/dao/GuideEnvironmentDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GuideEnvironmentDao.scala
@@ -1,0 +1,161 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.dao.meta._
+import gem.enum.{ GuideGroupType, Instrument }
+import gem.enum.Guider._
+import gem.enum.Instrument._
+import gem.math.Index
+import gem.syntax.treemap._
+import gem.util.Zipper
+
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+import scala.collection.immutable.TreeMap
+import scala.reflect.runtime.universe._
+
+
+final case class ProtoGuideGroup(
+  gid:       GuideGroup.Id,
+  pid:       Program.Id,
+  inst:      Instrument,
+  obsIndex:  Index,
+  groupType: GuideGroupType,
+  selected:  Boolean
+)
+
+object GuideEnvironmentDao {
+
+  def selectObs(
+    oid:  Observation.Id
+  ): ConnectionIO[Option[GuideEnvironment]] =
+    for {
+      gs <- Statements.selectObs(oid).to[List]
+      ss <- GuideStarDao.selectObs(oid)
+    } yield guideEnvironment(gs, ss)
+
+  def selectProg(
+    pid: Program.Id
+  ): ConnectionIO[TreeMap[Index, Option[GuideEnvironment]]] =
+    for {
+      gs <- Statements.selectProg(pid).to[List]
+      ss <- GuideStarDao.selectProg(pid)
+    } yield TreeMap.grouping(gs)(_.obsIndex).mergeMatchingKeys(ss) { (obsGroups, obsStars) =>
+      obsStars.flatMap(guideEnvironment(obsGroups, _))
+    }
+
+
+  // Assemble all the groups and guide stars into an actual GuideEnvironment
+  private object guideEnvironment {
+    type GroupResolver[T] = PartialFunction[List[ResolvedGuideStar], T]
+
+    val flamingos2: GroupResolver[GuideGroup.Flamingos2] = {
+      case List(ResolvedGuideStar(t, F2OI, Flamingos2)) => GuideGroup.Flamingos2.OI(t)
+      case List(ResolvedGuideStar(t, P1GS, Flamingos2)) => GuideGroup.Flamingos2.P1(t)
+      case List(ResolvedGuideStar(t, P2GS, Flamingos2)) => GuideGroup.Flamingos2.P2(t)
+    }
+
+    val gmosNorth: GroupResolver[GuideGroup.GmosNorth] = {
+      case List(ResolvedGuideStar(t, GmosNOI, GmosN)) => GuideGroup.GmosNorth.OI(t)
+      case List(ResolvedGuideStar(t, P1GN,    GmosN)) => GuideGroup.GmosNorth.P1(t)
+      case List(ResolvedGuideStar(t, P2GN,    GmosN)) => GuideGroup.GmosNorth.P2(t)
+    }
+
+    val gmosSouth: GroupResolver[GuideGroup.GmosSouth] = {
+      case List(ResolvedGuideStar(t, GmosSOI, GmosS)) => GuideGroup.GmosSouth.OI(t)
+      case List(ResolvedGuideStar(t, P1GS,    GmosS)) => GuideGroup.GmosSouth.P1(t)
+      case List(ResolvedGuideStar(t, P2GS,    GmosS)) => GuideGroup.GmosSouth.P2(t)
+    }
+
+    // Partition the manual guide groups into Left[GuideGroup.Id] if none is
+    // select or else Zipper[GuideGroup.Id] if there is a selection.
+    def manual(ps: List[ProtoGuideGroup]): Either[List[GuideGroup.Id], Zipper[GuideGroup.Id]] =
+      ps.span(!_.selected) match {
+        case (lefts, focus :: rights) => Zipper(lefts.reverse, focus, rights).map(_.gid).asRight
+        case (all,   Nil            ) => all.map(_.gid).asLeft
+      }
+
+    // Shape the group list into a GuideOptions[GuideGroup.Id] according to
+    // which is auto (if any) vs. manual and which is selected (if any).  This
+    // will have the right GuideOptions structure, but the elements will be
+    // GuideOptions[GuideGroup.Id] instead of the typed GuideGroup.{instrument}.
+    def shape(ps: List[ProtoGuideGroup]): GuideOptions[GuideGroup.Id] =
+      ps.partition(_.groupType === GuideGroupType.Automatic) match {
+        case (Nil,     ms) => GuideOptions(None,        manual(ms))
+        case (List(a), ms) => GuideOptions(Some(a.gid), manual(ms))
+        case (as,       _) =>
+          sys.error(s"Multiple auto guide groups: $as")
+      }
+
+    def instrument(protos: List[ProtoGuideGroup]): Option[Instrument] =
+      protos.map(_.inst).distinct match {
+        case Nil     => None
+        case List(i) => Some(i)
+        case x       =>
+          sys.error(s"Cannot create a guide environment for multiple instruments: $x")
+      }
+
+    def apply(
+      protos: List[ProtoGuideGroup],
+      stars:  Map[GuideGroup.Id, List[ResolvedGuideStar]]
+    ): Option[GuideEnvironment] = {
+
+      def options[T: TypeTag](gr: GroupResolver[T]): GuideOptions[T] = {
+        val groups: Map[GuideGroup.Id, T] = stars.mapValues { s =>
+          gr.applyOrElse(s, (_: List[ResolvedGuideStar]) => sys.error(s"Could not create a group of type ${typeOf[T]} from $s"))
+        }
+
+        shape(protos).map { gid =>
+          groups.getOrElse(gid, sys.error(s"Missing guide group with id $gid"))
+        }
+      }
+
+      instrument(protos).map {
+        case Flamingos2 => GuideEnvironment.Flamingos2(options(flamingos2))
+        case GmosN      => GuideEnvironment.GmosNorth(options(gmosNorth))
+        case GmosS      => GuideEnvironment.GmosSouth(options(gmosSouth))
+        case inst       =>
+          sys.error(s"Cannot create a guide environment for $inst")
+      }
+    }
+
+  }
+
+
+  object Statements {
+
+    import EnumeratedMeta._
+    import IndexMeta._
+    import ProgramIdMeta._
+
+    private val selectGuideGroup: Fragment =
+      Fragment.const(
+        """
+          SELECT id,
+                 program_id,
+                 observation_index,
+                 instrument,
+                 type,
+                 selected
+            FROM guide_group
+        """
+      )
+
+    private def selectWhere(where: Fragment): Query0[ProtoGuideGroup] =
+      (selectGuideGroup ++ where).query[ProtoGuideGroup]
+
+    def selectObs(oid: Observation.Id): Query0[ProtoGuideGroup] =
+      selectWhere(fr"WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}")
+
+    def selectProg(pid: Program.Id): Query0[ProtoGuideGroup] =
+      selectWhere(fr"WHERE program_id = $pid")
+
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/GuideStarDao.scala
+++ b/modules/db/src/main/scala/gem/dao/GuideStarDao.scala
@@ -1,0 +1,152 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.dao.meta._
+import gem.enum.{ Guider, Instrument }
+import gem.math.Index
+
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+import scala.collection.immutable.TreeMap
+
+
+final case class ProtoGuideStar(
+  id:       GuideStar.Id,
+  groupId:  GuideGroup.Id,
+  targetId: Target.Id,
+  guider:   Guider,
+  obsIndex: Index
+) extends ProtoTargetWrapper[GuideStar.Id, (Target, Guider)] {
+
+  override def wrap(t: Target): (Target, Guider) =
+    (t, guider)
+
+}
+
+object GuideStarDao extends TargetWrapperDao[GuideStar.Id, (Target, Guider), ProtoGuideStar] {
+
+  def insert(
+    gid:        GuideGroup.Id,
+    target:     Target,
+    guider:     Guider,
+    oid:        Observation.Id,
+    instrument: Instrument
+  ): ConnectionIO[GuideStar.Id] =
+    for {
+      t <- TargetDao.insert(target)
+      i <- Statements.insert(gid, t, guider, oid, instrument)
+                     .withUniqueGeneratedKeys[Int]("id")
+                     .map(GuideStar.Id(_))
+    } yield i
+
+
+  def select(
+    id: GuideStar.Id
+  ): ConnectionIO[Option[(Target, Guider)]] =
+    selectOne(Statements.select(id))
+
+  def selectGroup(
+    gid: GuideGroup.Id
+  ): ConnectionIO[List[(Target, Guider)]] =
+    selectAll(Statements.selectGroup(gid))
+      .map(wrapAll)
+
+  def selectGroupWithId(
+    gid: GuideGroup.Id
+  ): ConnectionIO[TreeMap[GuideStar.Id, (Target, Guider)]] =
+    selectAll(Statements.selectGroup(gid))
+      .map(groupById)
+
+  def selectObs(
+    oid: Observation.Id
+  ): ConnectionIO[TreeMap[GuideGroup.Id, List[(Target, Guider)]]] =
+    selectAll(Statements.selectObs(oid))
+      .map(groupAndMap(_.groupId, wrapAll))
+
+  def selectObsWithId(
+    oid: Observation.Id
+  ): ConnectionIO[TreeMap[GuideGroup.Id, TreeMap[GuideStar.Id, (Target, Guider)]]] =
+    selectAll(Statements.selectObs(oid))
+      .map(groupAndMap(_.groupId, groupById))
+
+  def selectProg(
+    pid: Program.Id
+  ): ConnectionIO[TreeMap[Index, TreeMap[GuideGroup.Id, List[(Target, Guider)]]]] =
+    selectAll(Statements.selectProg(pid))
+      .map(groupAndMap(_.obsIndex, groupAndMap(_.groupId, wrapAll)))
+
+  def selectProgWithId(
+    pid: Program.Id
+  ): ConnectionIO[TreeMap[Index, TreeMap[GuideGroup.Id, TreeMap[GuideStar.Id, (Target, Guider)]]]] =
+    selectAll(Statements.selectProg(pid))
+      .map(groupAndMap(_.obsIndex, groupAndMap(_.groupId, groupById)))
+
+  object Statements {
+
+    import EnumeratedMeta._
+
+    import gem.dao.meta.ProgramIdMeta._
+    import gem.dao.meta.IndexMeta._
+
+    def insert(
+      gid:        GuideGroup.Id,
+      tid:        Target.Id,
+      guider:     Guider,
+      oid:        Observation.Id,
+      instrument: Instrument
+    ): Update0 =
+      sql"""
+        INSERT INTO guide_star (
+          group_id,
+          target_id,
+          guider,
+          guider_instrument,
+          program_id,
+          observation_index,
+          instrument
+        ) VALUES (
+          $gid,
+          $tid,
+          $guider,
+          ${guider.instrument},
+          ${oid.pid},
+          ${oid.index},
+          $instrument
+        )
+      """.update
+
+    private val selectGuideStar: Fragment =
+      Fragment.const(
+        """
+           SELECT id,
+                  group_id,
+                  target_id,
+                  guider,
+                  observation_index
+             FROM guide_star
+        """
+      )
+
+    private def selectWhere(where: Fragment): Query0[ProtoGuideStar] =
+      (selectGuideStar ++ where).query[ProtoGuideStar]
+
+    def select(id: GuideStar.Id): Query0[ProtoGuideStar] =
+      selectWhere(fr"WHERE id = $id")
+
+    def selectGroup(gid: GuideGroup.Id): Query0[ProtoGuideStar] =
+      selectWhere(fr"WHERE group_id = $gid")
+
+    def selectObs(oid: Observation.Id): Query0[ProtoGuideStar] =
+      selectWhere(fr"WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}")
+
+    def selectProg(pid: Program.Id): Query0[ProtoGuideStar] =
+      selectWhere(fr"WHERE program_id = $pid")
+  }
+
+}

--- a/modules/db/src/main/scala/gem/dao/TargetWrapperDao.scala
+++ b/modules/db/src/main/scala/gem/dao/TargetWrapperDao.scala
@@ -1,0 +1,109 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+
+import gem.syntax.treemap._
+
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+
+import scala.collection.immutable.TreeMap
+
+/**
+ * A proto-target wrapper. A target wrapper refers to a class that wraps a
+ * Target instance and adds some additional data such as an associated category
+ * of target or guide probe meant to observe the target.  A proto-target
+ * wrapper collects data used for grouping target wrappers in various ways.
+ * The target wrapper itself can be instantiated by providing the target to
+ * wrap.
+ *
+ * For example, `UserTarget` wraps a target and adds a `UserTargetType` to
+ * differentiate user targets that are blind offsets from those that are tuning
+ * stars, etc.  A `GuideTarget` wraps a target and adds a guide probe that
+ * should be used to observe it.
+ *
+ * @tparam I target wrapper id type
+ * @tparam W target wrapper type
+ */
+trait ProtoTargetWrapper[I, W] {
+  def id: I
+  def targetId: Target.Id
+
+  /** Instantiates the target wrapper with the supplied Target instance. */
+  def wrap(t: Target): W
+}
+
+/**
+ * Support for selecting target wrappers and grouping them in various ways. For
+ * instance, all the user targets for a particular observation.
+ *
+ * @tparam I id type of the target wrapper
+ * @tparam W target wrapper type
+ * @tparam P proto-target wrapper type
+ */
+trait TargetWrapperDao[I, W, P <: ProtoTargetWrapper[I, W]] {
+
+  // A selection of proto target wrappers the corresponding target.
+  protected type Selection = List[(P, Target)]
+
+  /**
+   * Selects a single proto target wrapper and instantiates it to a target
+   * wrapper.
+   */
+  protected def selectOne(query: Query0[P]): ConnectionIO[Option[W]] = {
+    def lookupAndWrap(p: P): ConnectionIO[Option[W]] =
+      TargetDao.select(p.targetId).map(_.map(p.wrap))
+
+    for {
+      p <- query.option
+      w <- p.fold(Option.empty[W].pure[ConnectionIO])(lookupAndWrap)
+    } yield w
+  }
+
+  /**
+   * Selects all the target wrappers according to the query and pairs them with
+   * the corresponding target.
+   */
+  protected def selectAll(query: Query0[P]): ConnectionIO[Selection] =
+    for {
+      ps <- query.to[List]
+      ts <- ps.map(_.targetId).traverse(TargetDao.select)
+    } yield ps.zip(ts).flatMap { case (p, ot) =>
+      ot.map(t => (p, t)).toList
+    }
+
+  /** Groups a selection according to its unique id. */
+  protected def groupById(sel: Selection)(implicit ev: Ordering[I]): TreeMap[I, W] =
+    sel.foldLeft(TreeMap.empty[I, W]) { case (m, (p, t)) =>
+      m.updated(p.id, p.wrap(t))
+    }
+
+  /**
+   * Groups a selection according to a grouping function then maps each group
+   * according to a mapping function.
+   *
+   * @param gf grouping function
+   * @param mf mapping function
+   * @param sel selection of proto-target wrapper and target
+   *
+   * @tparam A key type of the grouping
+   * @tparam B type of the mapped values
+   */
+  protected def groupAndMap[A: Ordering, B](
+    gf: P         => A,
+    mf: Selection => B
+  )(sel: Selection): TreeMap[A, B] =
+    TreeMap.grouping(sel) { case (p, _) => gf(p) }
+           .treeMapValues(mf)
+
+  /**
+   * Instantiates the target wrapper for each element of the selection. This
+   * is expected to be the last step after any groupings by the information
+   * kept in the proto-target wrapper have been performed.
+   */
+  protected def wrapAll(sel: Selection): List[W] =
+    sel.map { case (p, t) => p.wrap(t) }
+}

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -12,17 +12,23 @@ import gem.syntax.treesetcompanion._
 import cats.implicits._
 import doobie._, doobie.implicits._
 
-import scala.collection.immutable.TreeSet
+import scala.collection.immutable.{ TreeMap, TreeSet }
 
-object UserTargetDao {
+// A target ID and the corresponding user target type.  We use the id to get the
+// actual target.
+final case class ProtoUserTarget(
+  id:         UserTarget.Id,
+  targetId:   Target.Id,
+  targetType: UserTargetType,
+  obsIndex:   Index
+) extends ProtoTargetWrapper[UserTarget.Id, UserTarget] {
 
-  // A target ID and the corresponding user target type.  We use the id to
-  // get the actual target.
-  final case class ProtoUserTarget(targetId: Target.Id, targetType: UserTargetType, oi: Index) {
+  override def wrap(t: Target): UserTarget =
+    UserTarget(t, targetType)
 
-    val toUserTarget: ConnectionIO[Option[UserTarget]] =
-      TargetDao.select(targetId).map { _.map(UserTarget(_, targetType)) }
-  }
+}
+
+object UserTargetDao extends TargetWrapperDao[UserTarget.Id, UserTarget, ProtoUserTarget] {
 
   import EnumeratedMeta._
   import ObservationIdMeta._
@@ -37,47 +43,35 @@ object UserTargetDao {
 
   /** Selects the single `UserTarget` associated with the given id, if any. */
   def select(id: UserTarget.Id): ConnectionIO[Option[UserTarget]] =
-    for {
-      oput <- Statements.select(id).option
-      out  <- oput.fold(Option.empty[UserTarget].pure[ConnectionIO]) { _.toUserTarget }
-    } yield out
+    selectOne(Statements.select(id))
 
-  private def selectAll(
-    targetsQuery: Query0[(UserTarget.Id, ProtoUserTarget)]
-  ): ConnectionIO[List[(Index, (UserTarget.Id, UserTarget))]] =
-    for {
-      puts <- targetsQuery.to[List]                              // List[(UserTarget.Id, ProtoUserTarget)]
-      ots  <- puts.map(_._2.targetId).traverse(TargetDao.select) // List[Option[Target]]
-    } yield puts.zip(ots).flatMap { case ((id, put), ot) =>
-      ot.map(t => (put.oi, (id, UserTarget(t, put.targetType)))).toList
-    }
-
-  private def toUserTargetSet(lst: List[(UserTarget.Id, UserTarget)]): TreeSet[UserTarget] =
-    TreeSet.fromList(lst.unzip._2)
-
-  /** Selects all `UserTarget`s for an observation.
-    */
+  /**
+   * Selects all `UserTarget`s for an observation.
+   */
   def selectObs(oid: Observation.Id): ConnectionIO[TreeSet[UserTarget]] =
-    selectObsWithId(oid).map(toUserTargetSet)
+    selectAll(Statements.selectObs(oid)).map(lst => TreeSet.fromList(wrapAll(lst)))
 
-  /** Selects all `UserTarget`s for an observation paired with the `UserTarget`
-    * id itself.
-    */
-  def selectObsWithId(oid: Observation.Id): ConnectionIO[List[(UserTarget.Id, UserTarget)]] =
-    selectAll(Statements.selectObs(oid)).map(_.unzip._2)
+  /**
+   * Selects all `UserTarget`s for an observation paired with the `UserTarget`
+   * id itself.
+   */
+  def selectObsWithId(oid: Observation.Id): ConnectionIO[TreeMap[UserTarget.Id, UserTarget]] =
+    selectAll(Statements.selectObs(oid)).map(groupById)
 
-  /** Selects all `UserTarget`s for a program.
-    */
+  /**
+   * Selects all `UserTarget`s for a program.
+   */
   def selectProg(pid: Program.Id): ConnectionIO[Map[Index, TreeSet[UserTarget]]] =
-    selectProgWithId(pid).map(_.mapValues(toUserTargetSet))
+    selectAll(Statements.selectProg(pid))
+      .map(groupAndMap(_.obsIndex, lst => TreeSet.fromList(wrapAll(lst))))
 
-  /** Selects all `UserTarget`s for a program paired with the `UserTarget` id
-    * itself.
-    */
-  def selectProgWithId(pid: Program.Id): ConnectionIO[Map[Index, List[(UserTarget.Id, UserTarget)]]] =
-    selectAll(Statements.selectProg(pid)).map {
-      _.groupBy(_._1).mapValues(_.unzip._2)
-    }
+  /**
+   * Selects all `UserTarget`s for a program paired with the `UserTarget` id
+   * itself.
+   */
+  def selectProgWithId(pid: Program.Id): ConnectionIO[TreeMap[Index, TreeMap[UserTarget.Id, UserTarget]]] =
+    selectAll(Statements.selectProg(pid))
+      .map(groupAndMap(_.obsIndex, groupById))
 
 
   object Statements {
@@ -104,14 +98,15 @@ object UserTargetDao {
 
     def select(id: UserTarget.Id): Query0[ProtoUserTarget] =
       sql"""
-        SELECT target_id,
+        SELECT id,
+               target_id,
                user_target_type,
                observation_index
           FROM user_target
          WHERE id = $id
       """.query[ProtoUserTarget]
 
-    def selectObs(oid: Observation.Id): Query0[(UserTarget.Id, ProtoUserTarget)] =
+    def selectObs(oid: Observation.Id): Query0[ProtoUserTarget] =
       sql"""
         SELECT id,
                target_id,
@@ -119,9 +114,9 @@ object UserTargetDao {
                observation_index
           FROM user_target
          WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}
-      """.query[(UserTarget.Id, ProtoUserTarget)]
+      """.query[ProtoUserTarget]
 
-    def selectProg(pid: Program.Id): Query0[(UserTarget.Id, ProtoUserTarget)] =
+    def selectProg(pid: Program.Id): Query0[ProtoUserTarget] =
       sql"""
         SELECT id,
                target_id,
@@ -129,7 +124,7 @@ object UserTargetDao {
                observation_index
           FROM user_target
          WHERE program_id = $pid
-      """.query[(UserTarget.Id, ProtoUserTarget)]
+      """.query[ProtoUserTarget]
 
   }
 }

--- a/modules/db/src/test/scala/gem/dao/check/GuideStarCheck.scala
+++ b/modules/db/src/test/scala/gem/dao/check/GuideStarCheck.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package dao
+package check
+
+import gem.enum.Guider
+import gem.enum.Instrument.GmosN
+
+class GuideStarCheck extends Check {
+
+  import GuideStarDao.Statements._
+
+  "GuideStarDao" should
+            "insert"      in check(insert(GuideGroup.Id(0), Target.Id(0), Guider.GmosSOI, Dummy.observationId, GmosN))
+  it should "select"      in check(select(GuideStar.Id(0)))
+  it should "selectGroup" in check(selectGroup(GuideGroup.Id(0)))
+  it should "selectObs"   in check(selectObs(Dummy.observationId))
+  it should "selectProg"  in check(selectProg(Dummy.programId))
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -192,6 +192,7 @@ object Decoders {
         }
       })
 
+    // TODO: GuideEnvironment
     PioDecoder { n =>
       for {
         a <- validTargets(n \* "&asterism" \! "&target")(_.toRequired).decode[Target]
@@ -199,13 +200,14 @@ object Decoders {
         u <- validTargets(n \? "&userTargets" \* "&userTarget")(_ \! "&spTarget" \! "&target").decode[UserTarget]
       } yield {
         a.headOption.map(Asterism.unsafeFromSingleTarget(_, i)) match {
-          case None    => TargetEnvironment.fromInstrument(i, TreeSet.fromList(u))
-          case Some(a) => TargetEnvironment.fromAsterism(a, TreeSet.fromList(u))
+          case None    => TargetEnvironment.fromInstrument(i, None, TreeSet.fromList(u))
+          case Some(a) => TargetEnvironment.fromAsterism(a, None, TreeSet.fromList(u))
         }
       }
     }
   }
 
+  // TODO: GuideEnvironment
   implicit val ObservationDecoder: PioDecoder[Observation] =
     PioDecoder { n =>
       for {
@@ -213,7 +215,7 @@ object Decoders {
         s <- (n \! "sequence"                           ).decode[StaticConfig](StaticDecoder)
         d <- (n \! "sequence"                           ).decode[List[Step]](SequenceDecoder)
         i  = Instrument.forStaticConfig(s) // stable identifier needed below
-        e <- (n \? "telescope" \! "data" \! "&targetEnv").decodeOrElse(TargetEnvironment.fromInstrument(i, TreeSet.empty))(targetEnvironmentDecoder(i))
+        e <- (n \? "telescope" \! "data" \! "&targetEnv").decodeOrElse(TargetEnvironment.fromInstrument(i, None, TreeSet.empty))(targetEnvironmentDecoder(i))
       } yield Observation.unsafeAssemble(t, e, s, d)
     }
 

--- a/modules/sql/src/main/resources/db/migration/V061__GuideStars.sql
+++ b/modules/sql/src/main/resources/db/migration/V061__GuideStars.sql
@@ -1,0 +1,91 @@
+--
+-- Initial Guide Star Support
+--
+
+-- An enumeration of the available guide probes / guide windows along with
+-- their associated instrument, if any.
+CREATE TABLE e_guider (
+  id         text       PRIMARY KEY,
+  instrument identifier REFERENCES e_instrument,
+  short_name text       NOT NULL,
+  long_name  text       NOT NULL,
+  UNIQUE (id, instrument) -- FK referent
+);
+
+ALTER TABLE e_guider OWNER to postgres;
+
+COPY e_guider (id, instrument, short_name, long_name) FROM stdin;
+F2OI	Flamingos2	F2 OI	Flamingos2 OIWFS
+GmosNOI	GmosN	GMOS-N OI	GMOS North OIWFS
+GmosSOI	GmosS	GMOS-S OI	GMOS South OIWFS
+P1GN	\N	P1 GN	PWFS1 North
+P2GN	\N	P2 GN	PWFS2 North
+P1GS	\N	P1 GS	PWFS1 South
+P2GS	\N	P2 GS	PWFS2 South
+\.
+
+
+--
+-- Guide groups are either automatically assigned and managed or else manual.
+-- 
+
+CREATE TYPE guide_group_type AS ENUM (
+  'Automatic',
+  'Manual'
+);
+
+ALTER TYPE guide_group_type OWNER TO postgres;
+
+
+--
+-- Guide groups are a collection of guide stars, each assigned to a distinct
+-- guider.
+--
+
+CREATE TABLE guide_group (
+  id                SERIAL           PRIMARY KEY,
+  program_id        text             NOT NULL,
+  observation_index id_index         NOT NULL,
+  instrument        identifier       NOT NULL REFERENCES e_instrument,
+  type              guide_group_type NOT NULL,
+  selected          boolean          NOT NULL,
+  FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE
+);
+
+ALTER TABLE guide_group OWNER TO postgres;
+
+-- Only one selected group per observation
+CREATE UNIQUE INDEX selected_guide_group
+  ON guide_group(program_id, observation_index)
+  WHERE (selected);
+
+-- Only one auto group per observation
+CREATE UNIQUE INDEX auto_guide_group
+  ON guide_group(program_id, observation_index)
+  WHERE (type = 'Automatic');
+
+
+--
+-- A guide star ties a target to the guide group (and observation).
+--
+
+CREATE TABLE guide_star (
+  id                SERIAL     PRIMARY KEY,
+  group_id          integer    NOT NULL     REFERENCES guide_group(id) ON DELETE CASCADE,
+  target_id         integer    NOT NULL     REFERENCES target(id),
+
+  guider            identifier NOT NULL     REFERENCES e_guider(id),
+  guider_instrument identifier              REFERENCES e_instrument, -- NOTE: This is nullable for PWFS
+  FOREIGN KEY (guider, guider_instrument)   REFERENCES e_guider(id, instrument),
+
+  program_id        text       NOT NULL,
+  observation_index id_index   NOT NULL,
+  instrument        identifier NOT NULL     REFERENCES e_instrument,
+  FOREIGN KEY (program_id, observation_index, instrument) REFERENCES observation ON DELETE CASCADE,
+
+  UNIQUE (group_id, guider), -- No group should have more than one guide star assigned to a particular guider
+  CHECK ((guider_instrument IS NULL) OR (instrument = guider_instrument))
+);
+
+ALTER TABLE guide_star OWNER TO postgres;
+

--- a/modules/sql/src/main/resources/db/migration/V064__GuideStars.sql
+++ b/modules/sql/src/main/resources/db/migration/V064__GuideStars.sql
@@ -27,7 +27,7 @@ P2GS	\N	P2 GS	PWFS2 South
 
 --
 -- Guide groups are either automatically assigned and managed or else manual.
--- 
+--
 
 CREATE TYPE guide_group_type AS ENUM (
   'Automatic',
@@ -41,6 +41,8 @@ ALTER TYPE guide_group_type OWNER TO postgres;
 -- Guide groups are a collection of guide stars, each assigned to a distinct
 -- guider.
 --
+
+-- TODO: GuideEnvironment: these are ordered so we'll need an group index :-(
 
 CREATE TABLE guide_group (
   id                SERIAL           PRIMARY KEY,

--- a/modules/sql/src/main/scala/gem/sql/EnumDef.scala
+++ b/modules/sql/src/main/scala/gem/sql/EnumDef.scala
@@ -35,6 +35,7 @@ object EnumDef {
     implicit def caseOptionArcseconds[S] = at[(S, Option[Arcseconds])] { _ =>  Some("gem.math.Angle") }
     implicit def caseOptionDegrees[S] = at[(S, Option[Degrees])] { _ =>  Some("gem.math.Angle") }
     implicit def caseOptionDouble[S] = at[(S, Option[Double])] { _ =>  Option.empty[String] }
+    implicit def caseOptionInstrument[S] = at[(S, Option[Instrument])] { _ => Option.empty[String] }
     implicit def caseOptionWavelengthNm[S] = at[(S, Option[Wavelength.Nm])] { _ => Some("gem.math.Wavelength") }
     implicit def caseOptionWavelengthUm[S] = at[(S, Option[Wavelength.Um])] { _ => Some("gem.math.Wavelength") }
     implicit def caseMagnitudeSystem[S] = at[(S, MagnitudeSystem)] { _ => Option.empty[String] }
@@ -70,6 +71,8 @@ object EnumDef {
     implicit def caseOptionDegrees [S <: Symbol] = at[(S, Option[Degrees]) ] { case (s, _) => "  val " + s.name + ": Option[Angle]" }
     implicit def caseOptionDouble[S <: Symbol] = at[(S, Option[Double]) ] { case (s, _) => "  val " + s.name + ": Option[Double]" }
 
+    implicit def caseOptionInstrument[S <: Symbol] = at[(S, Option[Instrument])] { case (s, _) => s"  val ${s.name}: Option[Instrument]" }
+
     implicit def caseOptionWavelengthNm[S <: Symbol] = at[(S, Option[Wavelength.Nm])] { case (s, _) => s"  val ${s.name}: Option[Wavelength]" }
     implicit def caseOptionWavelengthUm[S <: Symbol] = at[(S, Option[Wavelength.Um])] { case (s, _) => s"  val ${s.name}: Option[Wavelength]" }
 
@@ -100,9 +103,12 @@ object EnumDef {
     implicit val caseDegrees      = at[Degrees    ](a => s"Angle.fromDoubleDegrees(${a.toDegrees})")
     implicit val caseZoneId       = at[ZoneId     ](a => s"""ZoneId.of("${a.toString}")""")
 
+    implicit val caseOptionInstrument = at[Option[Instrument]](a => a.fold("None")(aʹ => s"Some(Instrument.${aʹ.id})"))
+
     implicit val caseWavelengthPm    = at[Wavelength.Pm  ](a => s"""Wavelength.fromPicometers.unsafeGet(${a.toPicometers})""")
     implicit val caseWavelengthNm    = at[Wavelength.Nm  ](a => s"""Wavelength.fromPicometers.unsafeGet(${a.toPicometers})""")
     implicit val caseWavelengthUm    = at[Wavelength.Um  ](a => s"""Wavelength.fromPicometers.unsafeGet(${a.toPicometers})""")
+
     implicit val caseMagnitudeSystem = at[MagnitudeSystem](a => s"MagnitudeSystem.${a.id}")
 
     implicit val caseOptionArcseconds = at[Option[Arcseconds]](a => a.fold("Option.empty[Angle]")(aʹ => s"Some(Angle.fromDoubleArcseconds(${aʹ.toArcsecs}))"))

--- a/modules/sql/src/main/scala/gem/sql/Instrument.scala
+++ b/modules/sql/src/main/scala/gem/sql/Instrument.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.sql
+
+/**
+ * Minimal support for enum creation.
+ */
+final case class Instrument(id: String)

--- a/modules/sql/src/main/scala/gem/sql/enum/TargetEnums.scala
+++ b/modules/sql/src/main/scala/gem/sql/enum/TargetEnums.scala
@@ -21,6 +21,20 @@ object TargetEnums {
          """.query[(String, R)]
       },
 
+      EnumDef.fromQuery("Guider", "guider") {
+        type R = Record.`'tag -> String, 'instrument -> Option[Instrument], 'shortName -> String, 'longName -> String`.T
+        sql"SELECT id, id tag, instrument, short_name, long_name FROM e_guider".query[(String, R)]
+      },
+
+      EnumDef.fromQuery("GuideGroupType", "guide group types") {
+        type R = Record.`'tag -> String`.T
+        sql"""
+          SELECT enumlabel x, enumlabel y
+          FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+          WHERE pg_type.typname = 'guide_group_type'
+        """.query[(String, R)]
+      },
+
       EnumDef.fromQuery("TrackType", "track types") {
         type R = Record.`'tag -> String`.T
         sql"""

--- a/modules/ui/src/main/scala/gem/ui/Main.scala
+++ b/modules/ui/src/main/scala/gem/ui/Main.scala
@@ -44,7 +44,7 @@ object TestProgram {
   val f2: Observation.Flamingos2 =
     Observation.Flamingos2(
       "F2 Observation",
-      TargetEnvironment.Flamingos2(None, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
+      TargetEnvironment.Flamingos2(None, GuideEnvironment.Flamingos2.empty, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
       StaticConfig.Flamingos2.Default,
       List(DynamicConfig.Flamingos2.Default.toStep(Step.Base.Gcal(gcal)))
     )
@@ -52,7 +52,7 @@ object TestProgram {
   val gmosS: Observation.GmosS =
     Observation.GmosS(
       "GMOS-S Observation",
-      TargetEnvironment.GmosS(None, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
+      TargetEnvironment.GmosS(None, GuideEnvironment.GmosSouth.empty, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
       StaticConfig.GmosS.Default,
       List(DynamicConfig.GmosS.Default.toStep(Step.Base.SmartGcal(SmartGcalType.Arc)))
     )
@@ -60,7 +60,7 @@ object TestProgram {
   val gmosN: Observation.GmosN =
     Observation.GmosN(
       "GMOS-N Observation",
-      TargetEnvironment.GmosN(None, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
+      TargetEnvironment.GmosN(None, GuideEnvironment.GmosNorth.empty, TreeSet(UserTarget(vega, UserTargetType.BlindOffset))),
       StaticConfig.GmosN.Default,
       List(DynamicConfig.GmosN.Default.toStep(Step.Base.Bias))
     )


### PR DESCRIPTION
There is a lot of work left to be done but since I'm struggling with the best way to do this I wanted early feedback.  The challenge is assembling an observation with a consistent asterism and guide environment.  There is a lot here but really I'm focused on how to model this.  From the ground up we have:

* `GuideGroup` - this is basically a typed collection of pairs `(Guider, Target)`.  Usually it is just a single entry, for example GMOS North OI or PWFS2.  It can be more complex though if multiple guiders are involved (as for GSAOI/GeMS).  There are types for each valid guide group in order to prevent creating invalid groups like a Michelle observation with GMOS OI.

* `GuideOptions` - a parameterized type that combines multiple `GuideGroup` of the same broad instrument category into the selections for an observation.  For example, a `GuideOptions[GuideGroup.GmosNorth]` can contain GMOS OI or PWFS options that are valid for GMOS North. Basically this is an auto guide group (for AGS) and zero or more manual guide groups (because astronomers always want an override).

* `GuideEnvironment` - one per instrument where each contains an appropriately typed `GuideOptions`.  This is just `GuideOptions` with the type parameter having been eaten in order to create a `TargetEnvironment`.  For example, `GuideEnvironment.Flamingos2` which contains a `GuideOptions[GuideGroup.Flamingos2]`.

So this is a lot of complexity which makes me feel sheepish.  Do you guys have any suggestions for how to simplify it before I go much further? 