### PR TITLE
SEQNG-1056 All config reads use specialized telescope, instrument, observe functions.

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -11,7 +11,7 @@ import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY
 import edu.gemini.spModel.seqcomp.SeqConfigNames.TELESCOPE_KEY
 import edu.gemini.spModel.seqcomp.SeqConfigNames.CALIBRATION_KEY
-import edu.gemini.spModel.ao.AOConstants.AO_SYSTEM_KEY
+import edu.gemini.spModel.ao.AOConstants.AO_CONFIG_NAME
 import java.beans.PropertyDescriptor
 import java.lang.{Integer => JInt}
 import scala.reflect.ClassTag
@@ -82,6 +82,8 @@ object ConfigUtilOps {
       } yield b
   }
 
+  val AO_KEY: ItemKey = new ItemKey(AO_CONFIG_NAME)
+
   implicit class ExtractOps[C: ExtractItem](val c: C) {
     // config syntax: cfg.extract(key).as[Type]
     def extract(key: ItemKey): Extracted[C] = new Extracted(c, key)
@@ -134,12 +136,12 @@ object ConfigUtilOps {
     // config syntax: cfg.extractAOAs[Type](key)
     def extractAOAs[A](key: PropertyDescriptor)(
       implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
-      new Extracted(c, AO_SYSTEM_KEY / key).as[A]
+      new Extracted(c, AO_KEY / key).as[A]
 
     // config syntax: cfg.extractAOAs[Type](key)
     def extractAOAs[A](key: String)(
       implicit clazz: ClassTag[A]): Either[ExtractFailure, A] =
-      new Extracted(c, AO_SYSTEM_KEY / key).as[A]
+      new Extracted(c, AO_KEY / key).as[A]
 
     def extractInstInt[A](
       property: PropertyDescriptor

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
@@ -5,7 +5,6 @@ package seqexec.server
 
 import cats.implicits._
 import edu.gemini.spModel.obscomp.InstConstants._
-import edu.gemini.spModel.seqcomp.SeqConfigNames._
 import edu.gemini.spModel.gemini.altair.AltairConstants
 import edu.gemini.spModel.ao.AOConstants._
 import edu.gemini.spModel.core.Wavelength
@@ -28,7 +27,7 @@ import seqexec.server.CleanConfig.extractItem
 trait SequenceConfiguration {
   def extractInstrument(config: CleanConfig): Either[SeqexecFailure, Instrument] =
     config
-      .extractAs[String](INSTRUMENT_KEY / INSTRUMENT_NAME_PROP)
+      .extractInstAs[String](INSTRUMENT_NAME_PROP)
       .asTrySeq
       .flatMap {
         case Flamingos2.name => Instrument.F2.asRight
@@ -72,7 +71,7 @@ trait SequenceConfiguration {
       }
 
     (config
-       .extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
+       .extractObsAs[String](OBSERVE_TYPE_PROP)
        .leftMap(explainExtractError),
      extractInstrument(config)).mapN { (obsType, inst) =>
       obsType match {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -88,7 +88,7 @@ object Ghost {
 
   def fromSequenceConfig[F[_]: Sync](config: CleanConfig): F[GhostConfig] = {
     def extractor[A : ClassTag](propName: String): Option[A] =
-      config.extractAs[A](INSTRUMENT_KEY / propName).toOption
+      config.extractInstAs[A](propName).toOption
 
     def formatExtractor[A](fmt: Format[String, A]): String => Either[ExtractFailure, Option[A]] = { propName =>
       // 1. If content is None, trivial success, so Right(None).

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosKeywordReader.scala
@@ -12,7 +12,6 @@ import seqexec.server.keywords._
 import seqexec.server.gmos.GmosEpics.RoiStatus
 import edu.gemini.spModel.data.YesNoType
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.IS_MOS_PREIMAGING_PROP
-import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import seqexec.model.enum.NodAndShuffleStage.{StageA, StageB}
 import seqexec.server.{CleanConfig, ConfigUtilOps, SeqexecFailure}
 import seqexec.server.CleanConfig.extractItem
@@ -30,7 +29,7 @@ final case class GmosObsKeywordsReader[F[_]: MonadError[?[_], Throwable]](config
 
   def preimage: F[Boolean] = MonadError[F, Throwable].catchNonFatal(
     config
-      .extractAs[YesNoType](INSTRUMENT_KEY / IS_MOS_PREIMAGING_PROP)
+      .extractInstAs[YesNoType](IS_MOS_PREIMAGING_PROP)
       .getOrElse(YesNoType.NO)
       .toBoolean
   ).safeValOrDefault

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -18,7 +18,6 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
-import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import squants.Length
 import squants.space.Arcseconds
 
@@ -26,13 +25,13 @@ final case class GmosNorth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosNor
   new SiteSpecifics[NorthTypes] {
     override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
     override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
-      config.extractAs[NorthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
+      config.extractInstAs[NorthTypes#Filter](FILTER_PROP)
     override def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] =
-      config.extractAs[NorthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
+      config.extractInstAs[NorthTypes#Disperser](DISPERSER_PROP)
     override def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] =
-      config.extractAs[NorthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
+      config.extractInstAs[NorthTypes#FPU](FPU_PROP_NAME)
     override def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
-      config.extractAs[NorthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
+      config.extractInstAs[NorthTypes#GmosStageMode](STAGE_MODE_PROP)
   })(northConfigTypes) {
   override val resource: Instrument = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -18,7 +18,6 @@ import edu.gemini.spModel.gemini.gmos.GmosSouthType
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{FPU_PROP_NAME, STAGE_MODE_PROP}
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
-import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
 import squants.Length
 import squants.space.Arcseconds
 
@@ -26,13 +25,13 @@ final case class GmosSouth[F[_]: MonadError[?[_], Throwable]: Logger](c: GmosSou
   new SiteSpecifics[SouthTypes] {
     override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
     override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
-      config.extractAs[SouthTypes#Filter](INSTRUMENT_KEY / FILTER_PROP)
+      config.extractInstAs[SouthTypes#Filter](FILTER_PROP)
     override def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] =
-      config.extractAs[SouthTypes#Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
+      config.extractInstAs[SouthTypes#Disperser](DISPERSER_PROP)
     override def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] =
-      config.extractAs[SouthTypes#FPU](INSTRUMENT_KEY / FPU_PROP_NAME)
+      config.extractInstAs[SouthTypes#FPU](FPU_PROP_NAME)
     override def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
-      config.extractAs[SouthTypes#GmosStageMode](INSTRUMENT_KEY / STAGE_MODE_PROP)
+      config.extractInstAs[SouthTypes#GmosStageMode](STAGE_MODE_PROP)
   })(southConfigTypes) {
   override val resource: Instrument = Instrument.GmosS
   override val dhsInstrumentName: String = "GMOS-S"

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -11,7 +11,6 @@ import edu.gemini.spModel.gemini.gnirs.GNIRSConstants.{INSTRUMENT_NAME_PROP, WOL
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams._
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS._
 import edu.gemini.spModel.obscomp.InstConstants.{BIAS_OBSERVE_TYPE, DARK_OBSERVE_TYPE, OBSERVE_TYPE_PROP}
-import edu.gemini.spModel.seqcomp.SeqConfigNames.{INSTRUMENT_KEY, OBSERVE_KEY}
 import java.lang.{Double => JDouble, Integer => JInt}
 
 import gem.enum.LightSinkName
@@ -79,10 +78,10 @@ object Gnirs {
   val name: String = INSTRUMENT_NAME_PROP
 
   def extractExposureTime(config: CleanConfig): Either[ExtractFailure, Time] =
-    config.extractAs[JDouble](OBSERVE_KEY / EXPOSURE_TIME_PROP).map(_.toDouble.seconds)
+    config.extractObsAs[JDouble](EXPOSURE_TIME_PROP).map(_.toDouble.seconds)
 
   def extractCoadds(config: CleanConfig): Either[ExtractFailure, Int] =
-    config.extractAs[JInt](OBSERVE_KEY / COADDS_PROP).map(_.toInt)
+    config.extractObsAs[JInt](COADDS_PROP).map(_.toInt)
 
   def fromSequenceConfig(config: CleanConfig): TrySeq[GnirsController.GnirsConfig] =
     (getCCConfig(config), getDCConfig(config)).mapN(GnirsController.GnirsConfig)
@@ -90,12 +89,12 @@ object Gnirs {
   private def getDCConfig(config: CleanConfig): TrySeq[DCConfig] = (for {
     expTime <- extractExposureTime(config)
     coadds  <- extractCoadds(config)
-    readMode <- config.extractAs[ReadMode](INSTRUMENT_KEY / READ_MODE_PROP)
-    wellDepth <- config.extractAs[WellDepth](INSTRUMENT_KEY / WELL_DEPTH_PROP)
+    readMode <- config.extractInstAs[ReadMode](READ_MODE_PROP)
+    wellDepth <- config.extractInstAs[WellDepth](WELL_DEPTH_PROP)
   } yield DCConfig(expTime, coadds, readMode, wellDepth))
     .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
-  private def getCCConfig(config: CleanConfig): TrySeq[CCConfig] = config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
+  private def getCCConfig(config: CleanConfig): TrySeq[CCConfig] = config.extractObsAs[String](OBSERVE_TYPE_PROP)
     .leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))).flatMap{
     case DARK_OBSERVE_TYPE => GnirsController.Dark.asRight
     case BIAS_OBSERVE_TYPE => SeqexecFailure.Unexpected("Bias not supported for GNIRS").asLeft
@@ -112,17 +111,17 @@ object Gnirs {
   }
 
   private def getCCOtherConfig(config: CleanConfig): TrySeq[CCConfig] = (for {
-    xdisp   <- config.extractAs[CrossDispersed](INSTRUMENT_KEY / CROSS_DISPERSED_PROP)
-    woll    <- config.extractAs[WollastonPrism](INSTRUMENT_KEY / WOLLASTON_PRISM_PROP)
+    xdisp   <- config.extractInstAs[CrossDispersed](CROSS_DISPERSED_PROP)
+    woll    <- config.extractInstAs[WollastonPrism](WOLLASTON_PRISM_PROP)
     mode    <- getCCMode(config, xdisp, woll)
-    slit    <- config.extractAs[SlitWidth](INSTRUMENT_KEY / SLIT_WIDTH_PROP)
+    slit    <- config.extractInstAs[SlitWidth](SLIT_WIDTH_PROP)
     slitOp = getSlit(slit)
-    camera  <- config.extractAs[Camera](INSTRUMENT_KEY / CAMERA_PROP)
+    camera  <- config.extractInstAs[Camera](CAMERA_PROP)
     decker  <- getDecker(config, slit, woll, xdisp)
-    wavel   <- config.extractAs[Wavelength](INSTRUMENT_KEY / CENTRAL_WAVELENGTH_PROP).map(_.doubleValue().nanometers)
+    wavel   <- config.extractInstAs[Wavelength](CENTRAL_WAVELENGTH_PROP).map(_.doubleValue().nanometers)
     focus   <- getFocus(config)
-    filter  <- config.extractAs[Filter](INSTRUMENT_KEY / FILTER_PROP).optionalKey
-    hartm   <- config.extractAs[HartmannMask](INSTRUMENT_KEY / HARTMANN_MASK_PROP).optionalKey
+    filter  <- config.extractInstAs[Filter](FILTER_PROP).optionalKey
+    hartm   <- config.extractInstAs[HartmannMask](HARTMANN_MASK_PROP).optionalKey
     filter1 <- getFilter1(filter, hartm, slit, decker)
     filter2 = getFilter2(filter, xdisp)
   } yield Other(mode, camera, decker, filter1, filter2, focus, wavel, slitOp) )
@@ -131,8 +130,8 @@ object Gnirs {
   private def getCCMode(config: CleanConfig, xdispersed: CrossDispersed, woll: WollastonPrism)
   : Either[ExtractFailure, GnirsController.Mode] =
     for {
-      acq        <- config.extractAs[AcquisitionMirror](INSTRUMENT_KEY / ACQUISITION_MIRROR_PROP)
-      disperser  <- config.extractAs[Disperser](INSTRUMENT_KEY / DISPERSER_PROP)
+      acq        <- config.extractInstAs[AcquisitionMirror](ACQUISITION_MIRROR_PROP)
+      disperser  <- config.extractInstAs[Disperser](DISPERSER_PROP)
     } yield {
       if(acq === AcquisitionMirror.IN) GnirsController.Acquisition
       else xdispersed match {
@@ -145,9 +144,9 @@ object Gnirs {
 
   private def getDecker(config: CleanConfig, slit: SlitWidth, woll: WollastonPrism, xdisp: CrossDispersed)
   : Either[ExtractFailure, GnirsController.Decker] =
-    config.extractAs[Decker](INSTRUMENT_KEY / DECKER_PROP).orElse {
+    config.extractInstAs[Decker](DECKER_PROP).orElse {
       for {
-        pixScale <- config.extractAs[PixelScale](INSTRUMENT_KEY / PIXEL_SCALE_PROP)
+        pixScale <- config.extractInstAs[PixelScale](PIXEL_SCALE_PROP)
       } yield xdisp match {
         case CrossDispersed.LXD => Decker.LONG_CAM_X_DISP
         case CrossDispersed.SXD => Decker.SHORT_CAM_X_DISP

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -10,7 +10,6 @@ import cats.implicits._
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi._
 import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.OBSERVE_TYPE_PROP
-import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY
 import gem.enum.LightSinkName
 import io.chrisdavenport.log4cats.Logger
 import java.lang.{Double => JDouble}
@@ -106,7 +105,7 @@ object Gsaoi {
   private def extractObsType(
     config: CleanConfig
   ): Either[ExtractFailure, String] =
-    config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
+    config.extractObsAs[String](OBSERVE_TYPE_PROP)
 
   private def readCCConfig(config: CleanConfig): Either[ExtractFailure, CCConfig] =
     for {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/ObsKeywordReader.scala
@@ -304,7 +304,7 @@ object ObsKeywordReader extends ObsKeywordsReaderConstants {
     private val manualDarkOverride = "Dark"
 
     override def obsObject: F[String] =
-      config.extractAs[String](OBSERVE_KEY / OBJECT_PROP)
+      config.extractObsAs[String](OBJECT_PROP)
         .map(v => if (v === manualDarkValue) manualDarkOverride else v)
         .toOption
         .pure[F]
@@ -315,14 +315,14 @@ object ObsKeywordReader extends ObsKeywordsReaderConstants {
     override def pIReq: F[String] = "UNKNOWN".pure[F]
 
     override def sciBand: F[Int] =
-      config.extractAs[Integer](OBSERVE_KEY / SCI_BAND)
+      config.extractObsAs[Integer](SCI_BAND)
       .map(_.toInt)
       .toOption
       .pure[F]
       .safeValOrDefault
 
     def astrometicField: F[Boolean] =
-      config.extractAs[java.lang.Boolean](INSTRUMENT_KEY / ASTROMETRIC_FIELD_PROP)
+      config.extractInstAs[java.lang.Boolean](ASTROMETRIC_FIELD_PROP)
       .toOption
       .exists(Boolean.unbox)
       .pure[F]

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -13,7 +13,6 @@ import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.ARC_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.FLAT_OBSERVE_TYPE
 import edu.gemini.spModel.obscomp.InstConstants.OBSERVE_TYPE_PROP
-import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY
 import gem.enum.LightSinkName
 import io.chrisdavenport.log4cats.Logger
 import java.lang.{Double => JDouble}
@@ -201,7 +200,7 @@ object Nifs {
   private def extractObsType(
     config: CleanConfig
   ): Either[ExtractFailure, String] =
-    config.extractAs[String](OBSERVE_KEY / OBSERVE_TYPE_PROP)
+    config.extractObsAs[String](OBSERVE_TYPE_PROP)
 
   private def getDCConfig(config: CleanConfig): Either[ExtractFailure, DCConfig] =
     for {


### PR DESCRIPTION
Some time ago specialized functions were introduced to read telescope, instrument, ao, and observe parameters from a `Config`. I changed all the old code to use them, so things like `cfg.extractAs[String](INSTRUMENT_KEY / propName)` is now `cfg.extractAs[String](propName)`