### PR TITLE
Upgrade ui libs

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -26,10 +26,10 @@ object Settings {
     val diodeReact              = "1.1.5.142"
     val javaTimeJS              = "2.0.0-RC3"
     val scalaJQuery             = "1.2"
-    val scalaJSReactCommon      = "0.2.5"
-    val scalaJSReactVirtualized = "0.6.5"
+    val scalaJSReactCommon      = "0.3.0"
+    val scalaJSReactVirtualized = "0.7.0"
     val scalaJSReactClipboard   = "0.8.0"
-    val scalaJSReactDraggable   = "0.4.3"
+    val scalaJSReactDraggable   = "0.6.0"
     val scalaJSReactSortable    = "0.2.1"
     val reactSemanticUI         = "0.1.4"
 


### PR DESCRIPTION
Upgrade of some ui libs. Mostly they now depend on cats 2.x thus reducing eviction warnings