### PR TITLE
SEQNG-1218 Properly read the Observing wavelength from the OT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ val dateFormatter = java.time.format.DateTimeFormatter.BASIC_ISO_DATE
 
 inThisBuild(
   List(
+    scalaVersion in ThisBuild := "2.13.3",
     version := dateFormatter.format(
       dynverCurrentDate.value.toInstant.atZone(java.time.ZoneId.of("UTC")).toLocalDate
     ) + dynverGitDescribeOutput.value.mkVersion(versionFmt,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
@@ -51,7 +51,10 @@ trait SequenceConfiguration {
     }.getOrElse(StepState.Failed("Logical error reading step status"))
 
   def extractWavelength(config: CleanConfig): Option[Wavelength] =
-    config.extractAs[Wavelength](OBSERVING_WAVELENGTH_KEY).toOption
+    config
+      .extractAs[String](OBSERVING_WAVELENGTH_KEY)
+      .flatMap(v => Either.catchNonFatal(v.toDouble))
+      .map(Wavelength.fromMicrons[Double](_)).toOption
 
   def calcStepType(config: CleanConfig, isNightSeq: Boolean): TrySeq[StepType] = {
     def extractGaos(inst: Instrument): TrySeq[StepType] =


### PR DESCRIPTION
This fixes a fault reported where the Wavelength wasn't properly set on each step.
It was tracked to the value from the OT using a different type than expected and 
the error was silently discarded.
This makes the values of the Wavelength on the headers incorrect but worse the TCS
wasn't getting the correct values. It may invalidate some observations.