### PR TITLE
SEQNG-1218 Further refine the search for different Wavelengths sent b…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -308,7 +308,8 @@ lazy val seqexec_server = project
         PrometheusClient,
         Log4Cats.value,
         Log4CatsNoop.value,
-        TestLibs.value
+        TestLibs.value,
+        PPrint.value
       ) ++ Http4s ++ Http4sClient ++ PureConfig ++ SeqexecOdb ++ Monocle.value ++ WDBAClient ++
         Circe.value
   )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/CleanConfig.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/CleanConfig.scala
@@ -22,6 +22,8 @@ import seqexec.model.enum.SystemName
  */
 final case class CleanConfig(config: Config, overrides: Map[ItemKey, AnyRef]) {
 
+  def containsKey(k: ItemKey): Boolean = itemValue(k).isDefined
+
   def itemValue(k: ItemKey): Option[AnyRef] = overrides.get(k).orElse(Option(config.getItemValue(k)))
 
   private def sanitizeValue(s: Any): String = s match {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -11,6 +11,7 @@ import cats.implicits._
 import edu.gemini.seqexec.odb.{ExecutedDataset, SeqexecSequence}
 import edu.gemini.spModel.gemini.altair.AltairParams.GuideStarType
 import edu.gemini.spModel.obscomp.InstConstants.{DATA_LABEL_PROP, OBSERVE_TYPE_PROP, SCIENCE_OBSERVE_TYPE}
+import edu.gemini.spModel.core.Wavelength
 import fs2.Stream
 import gem.Observation
 import gem.enum.Site
@@ -323,29 +324,37 @@ object SeqTranslate {
     private def flatOrArcTcsSubsystems(inst: Instrument): NonEmptySet[TcsController.Subsystem] =
       NonEmptySet.of(AGUnit, (if (inst.hasOI) List(OIWFS) else List.empty): _*)
 
+    private def tryWavelength(inst: Instrument, config: CleanConfig): F[Option[Wavelength]] =
+      extractWavelength(config) match {
+        case Left(x) => Logger[F].error(s"Cannot decode the wavelength for ${inst.label}") *> MonadError[F, Throwable].raiseError(new SeqexecFailure.Execution(s"Cannot decode the wavelength from the sequence $x"))
+        case Right(w) => w.some.pure[F]
+      }
+
     private def getTcs(subs: NonEmptySet[TcsController.Subsystem], useGaos: Boolean, inst: InstrumentSystem[F],
-                       lsource: LightSource, config: CleanConfig): F[System[F]] = site match {
-      case Site.GS => if(useGaos)
-        Gems.fromConfig[F](systems.gems, systems.guideDb)(config).map(a =>
-          TcsSouth.fromConfig[F](systems.tcsSouth, subs, a.some, inst, systems.guideDb)(
-            config, LightPath(lsource, inst.sfName(config)), extractWavelength(config)
-          )
-        )
-        else
-          TcsSouth.fromConfig[F](systems.tcsSouth, subs, None, inst, systems.guideDb)(
-            config, LightPath(lsource, inst.sfName(config)), extractWavelength(config)
-          ).pure[F].widen[System[F]]
-      case Site.GN => if(useGaos)
-          Altair.fromConfig(config, systems.altair).map(a =>
-            TcsNorth.fromConfig[F](systems.tcsNorth, subs, a.some, inst, systems.guideDb)(
-              config, LightPath(lsource, inst.sfName(config)), extractWavelength(config)
+                       lsource: LightSource, config: CleanConfig): F[System[F]] =
+      tryWavelength(inst.instrument, config).flatMap{w => site match {
+          case Site.GS => if(useGaos)
+            Gems.fromConfig[F](systems.gems, systems.guideDb)(config).map(a =>
+              TcsSouth.fromConfig[F](systems.tcsSouth, subs, a.some, inst, systems.guideDb)(
+                config, LightPath(lsource, inst.sfName(config)), w
+              )
             )
-          )
-        else
-          TcsNorth.fromConfig[F](systems.tcsNorth, subs, none, inst, systems.guideDb)(
-            config, LightPath(lsource, inst.sfName(config)), extractWavelength(config)
-          ).pure[F].widen[System[F]]
-    }
+            else
+            TcsSouth.fromConfig[F](systems.tcsSouth, subs, None, inst, systems.guideDb)(
+                config, LightPath(lsource, inst.sfName(config)), w
+              ).pure[F].widen[System[F]]
+          case Site.GN => if(useGaos)
+              Altair.fromConfig(config, systems.altair).map(a =>
+                TcsNorth.fromConfig[F](systems.tcsNorth, subs, a.some, inst, systems.guideDb)(
+                  config, LightPath(lsource, inst.sfName(config)), w
+                )
+              )
+            else
+              TcsNorth.fromConfig[F](systems.tcsNorth, subs, none, inst, systems.guideDb)(
+                config, LightPath(lsource, inst.sfName(config)), w
+              ).pure[F].widen[System[F]]
+        }
+      }
 
     private def calcSystems(
       config: CleanConfig,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -327,7 +327,7 @@ object SeqTranslate {
     private def tryWavelength(inst: Instrument, config: CleanConfig): F[Option[Wavelength]] =
       extractWavelength(config) match {
         case Left(x) => Logger[F].error(s"Cannot decode the wavelength for ${inst.label}") *> MonadError[F, Throwable].raiseError(new SeqexecFailure.Execution(s"Cannot decode the wavelength from the sequence $x"))
-        case Right(w) => w.some.pure[F]
+        case Right(w) => w.pure[F]
       }
 
     private def getTcs(subs: NonEmptySet[TcsController.Subsystem], useGaos: Boolean, inst: InstrumentSystem[F],

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
@@ -59,15 +59,21 @@ trait SequenceConfiguration {
       .map(Wavelength.fromMicrons[Double](_))
       .orElse{
         // GNIRS uses its own wavelength!!
-        config.extractAs[GNIRSWavelength](OBSERVING_WAVELENGTH_KEY).map(w => Wavelength.fromMicrons(w.doubleValue()))
+        config
+          .extractAs[GNIRSWavelength](OBSERVING_WAVELENGTH_KEY)
+          .map(w => Wavelength.fromMicrons(w.doubleValue()))
       }.orElse{
         // Maybe we use ocs Wavelength
-        config.extractAs[Wavelength](OBSERVING_WAVELENGTH_KEY)
+        config
+          .extractAs[Wavelength](OBSERVING_WAVELENGTH_KEY)
       }.orElse{
         // Just in case
-        config.extractAs[java.lang.Double](OBSERVING_WAVELENGTH_KEY).map(v => Wavelength.fromMicrons[Double](v.doubleValue))
+        config
+          .extractAs[java.lang.Double](OBSERVING_WAVELENGTH_KEY)
+          .map(v => Wavelength.fromMicrons[Double](v.doubleValue))
       }.leftMap {
-        case e => Unexpected(s"Error reading wavelength ${config.itemValue(OBSERVING_WAVELENGTH_KEY)}: ${config.itemValue(OBSERVING_WAVELENGTH_KEY).getClass()}")
+        case _ =>
+          Unexpected(s"Error reading wavelength ${config.itemValue(OBSERVING_WAVELENGTH_KEY)}: ${config.itemValue(OBSERVING_WAVELENGTH_KEY).getClass()}")
       }
 
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
@@ -8,9 +8,9 @@ import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.gemini.altair.AltairConstants
 import edu.gemini.spModel.ao.AOConstants._
 import edu.gemini.spModel.core.Wavelength
+import edu.gemini.spModel.gemini.gnirs.GNIRSParams.{Wavelength => GNIRSWavelength}
 import seqexec.model.enum.Instrument
 import seqexec.model.StepState
-import seqexec.server.ConfigUtilOps._
 import seqexec.server.flamingos2.Flamingos2
 import seqexec.server.gpi.Gpi
 import seqexec.server.ghost.Ghost
@@ -23,6 +23,7 @@ import seqexec.server.gnirs._
 import seqexec.server.SeqexecFailure.UnrecognizedInstrument
 import seqexec.server.SeqexecFailure.Unexpected
 import seqexec.server.CleanConfig.extractItem
+import seqexec.server.ConfigUtilOps._
 
 trait SequenceConfiguration {
   def extractInstrument(config: CleanConfig): Either[SeqexecFailure, Instrument] =
@@ -50,13 +51,27 @@ trait SequenceConfiguration {
       case kw         => StepState.Failed("Unexpected status keyword: " ++ kw)
     }.getOrElse(StepState.Failed("Logical error reading step status"))
 
-  def extractWavelength(config: CleanConfig): Option[Wavelength] =
+  def extractWavelength(config: CleanConfig): Either[SeqexecFailure, Wavelength] =
+    // Gmos uses Stringg
     config
       .extractAs[String](OBSERVING_WAVELENGTH_KEY)
-      .flatMap(v => Either.catchNonFatal(v.toDouble))
-      .map(Wavelength.fromMicrons[Double](_)).toOption
+      .flatMap(v => Either.catchNonFatal(v.toDouble).leftMap(_ => new ContentError(v)))
+      .map(Wavelength.fromMicrons[Double](_))
+      .orElse{
+        // GNIRS uses its own wavelength!!
+        config.extractAs[GNIRSWavelength](OBSERVING_WAVELENGTH_KEY).map(w => Wavelength.fromMicrons(w.doubleValue()))
+      }.orElse{
+        // Maybe we use ocs Wavelength
+        config.extractAs[Wavelength](OBSERVING_WAVELENGTH_KEY)
+      }.orElse{
+        // Just in case
+        config.extractAs[java.lang.Double](OBSERVING_WAVELENGTH_KEY).map(v => Wavelength.fromMicrons[Double](v.doubleValue))
+      }.leftMap {
+        case e => Unexpected(s"Error reading wavelength ${config.itemValue(OBSERVING_WAVELENGTH_KEY)}: ${config.itemValue(OBSERVING_WAVELENGTH_KEY).getClass()}")
+      }
 
-  def calcStepType(config: CleanConfig, isNightSeq: Boolean): TrySeq[StepType] = {
+
+  def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] = {
     def extractGaos(inst: Instrument): TrySeq[StepType] =
       config.extractAs[String](AO_SYSTEM_KEY) match {
         case Left(ConfigUtilOps.ConversionError(_, _)) =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -244,8 +244,8 @@ object TcsController {
   trait AoGuide
 
   sealed trait GuiderSensorOption
-  object GuiderSensorOff extends GuiderSensorOption
-  object GuiderSensorOn extends GuiderSensorOption
+  case object GuiderSensorOff extends GuiderSensorOption
+  case object GuiderSensorOn extends GuiderSensorOption
   object GuiderSensorOption {
     implicit val guideSensorOptionEq: Eq[GuiderSensorOption] = Eq.fromUniversalEquals
   }


### PR DESCRIPTION
The OT sends different types in the `OBSERVING_WAVELENGTH` field. This was detected while testing and it affects GNIRS in particular.

This PR includes support for the `GNIRS` wavelength type and adds some extra safeguards for other possible types
The logic has been changed so that if we can't decode we'll in fact forbid loading a sequence. This is undesirable but better than allowing bad sequences to be executed.
Hopefully after this has been ironed out in testing we can go back to the simpler version of the code