### PR TITLE
Remove TrySeq alias

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -49,11 +49,9 @@ object ConfigUtilOps {
   def explainExtractError(e: ExtractFailure): SeqexecFailure =
     SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))
 
-  implicit class TrySeqed[A] private[server] (r: Either[ExtractFailure, A]) {
+  implicit class EitherExtractFailureOps[A] private[server] (r: Either[ExtractFailure, A]) {
     def adaptExtractFailure: Either[SeqexecFailure, A] = r.leftMap(explainExtractError)
-  }
 
-  implicit class ApplicativeErrored[A] private[server] (r: Either[ExtractFailure, A]) {
     def toF[F[_]: ApplicativeError[?[_], Throwable]]: F[A] = r.fold(explainExtractError(_).raiseError[F, A], _.pure[F])
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ConfigUtilOps.scala
@@ -50,10 +50,10 @@ object ConfigUtilOps {
     SeqexecFailure.Unexpected(ConfigUtilOps.explain(e))
 
   implicit class TrySeqed[A] private[server] (r: Either[ExtractFailure, A]) {
-    def asTrySeq: TrySeq[A] = r.leftMap(explainExtractError)
+    def adaptExtractFailure: Either[SeqexecFailure, A] = r.leftMap(explainExtractError)
   }
 
-  implicit class ApplicativeErrored[A] private[server] (r:Either[ExtractFailure, A]) {
+  implicit class ApplicativeErrored[A] private[server] (r: Either[ExtractFailure, A]) {
     def toF[F[_]: ApplicativeError[?[_], Throwable]]: F[A] = r.fold(explainExtractError(_).raiseError[F, A], _.pure[F])
   }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceConfiguration.scala
@@ -29,7 +29,7 @@ trait SequenceConfiguration {
   def extractInstrument(config: CleanConfig): Either[SeqexecFailure, Instrument] =
     config
       .extractInstAs[String](INSTRUMENT_NAME_PROP)
-      .asTrySeq
+      .adaptExtractFailure
       .flatMap {
         case Flamingos2.name => Instrument.F2.asRight
         case GmosSouth.name  => Instrument.GmosS.asRight
@@ -87,7 +87,7 @@ trait SequenceConfiguration {
 
 
   def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] = {
-    def extractGaos(inst: Instrument): TrySeq[StepType] =
+    def extractGaos(inst: Instrument): Either[SeqexecFailure, StepType] =
       config.extractAs[String](AO_SYSTEM_KEY) match {
         case Left(ConfigUtilOps.ConversionError(_, _)) =>
           Unexpected("Unable to get AO system from sequence").asLeft

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -20,7 +20,6 @@ import edu.gemini.spModel.gemini.altair.AltairParams.FieldLens
 import monocle.macros.Lenses
 import mouse.boolean._
 import seqexec.server.SeqexecFailure
-import seqexec.server.TrySeq
 import seqexec.server.altair.AltairController._
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import seqexec.server.tcs.Gaos._
@@ -150,7 +149,7 @@ object AltairControllerEpics {
       )
     }
 
-    private def checkStrapLoopState(currCfg: EpicsAltairConfig): TrySeq[Unit] =
+    private def checkStrapLoopState(currCfg: EpicsAltairConfig): Either[SeqexecFailure, Unit] =
       currCfg.strapRTStatus.either(
         SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, RT Control status is bad."), ()
       ) *>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -155,7 +155,7 @@ object Flamingos2 {
                                                 .map(_.getOrElse(default))
     }
 
-  def ccConfigFromSequenceConfig(config: CleanConfig): TrySeq[CCConfig] =
+  def ccConfigFromSequenceConfig(config: CleanConfig): Either[SeqexecFailure, CCConfig] =
     (for {
       obsType <- config.extractObsAs[String](OBSERVE_TYPE_PROP)
       // WINDOW_COVER_PROP is optional. It can be a WindowCover, an Option[WindowCover], or not be present. If no
@@ -173,7 +173,7 @@ object Flamingos2 {
     } yield CCConfig(p, q, r, s, t, u)).leftMap(e => SeqexecFailure.Unexpected
     (ConfigUtilOps.explain(e)))
 
-  def dcConfigFromSequenceConfig(config: CleanConfig): TrySeq[DCConfig] =
+  def dcConfigFromSequenceConfig(config: CleanConfig): Either[SeqexecFailure, DCConfig] =
     (for {
       p <- config.extractObsAs[JDouble](EXPOSURE_TIME_PROP).map(x => Duration(x, SECONDS))
       // Reads is usually inferred from the read mode, but it can be explicit.

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -127,7 +127,7 @@ abstract class Gmos[F[_]: Concurrent: Timer: Logger, T <: GmosController.SiteDep
         )
     }.getOrElse(ConfigUtilOps.ContentError(s"Disperser is missing an order.").asLeft)
 
-  private def ccConfigFromSequenceConfig(config: CleanConfig): TrySeq[configTypes.CCConfig] =
+  private def ccConfigFromSequenceConfig(config: CleanConfig): Either[SeqexecFailure, configTypes.CCConfig] =
     (for {
       filter           <- ss.extractFilter(config)
       disp             <- ss.extractDisperser(config)
@@ -263,7 +263,7 @@ object Gmos {
       pos    <- nsPosition(config, sc)
     } yield NSConfig.NodAndShuffle(tag[NsCyclesI][Int](cycles), tag[NsRowsI][Int](rows), pos, expTime(config))
 
-  def nsConfig(config: CleanConfig): TrySeq[NSConfig] =
+  def nsConfig(config: CleanConfig): Either[SeqexecFailure, NSConfig] =
     (for {
       useNS <- config.extractInstAs[java.lang.Boolean](USE_NS_PROP)
       ns    <- if (useNS) nodAndShuffle(config) else NSConfig.NoNodAndShuffle.asRight
@@ -319,7 +319,7 @@ object Gmos {
       (e / nsConfig.exposureDivider).seconds
     }
 
-  def dcConfigFromSequenceConfig(config: CleanConfig, nsConfig: NSConfig): TrySeq[DCConfig] =
+  def dcConfigFromSequenceConfig(config: CleanConfig, nsConfig: NSConfig): Either[SeqexecFailure, DCConfig] =
     (for {
       obsType      <- config.extractObsAs[String](OBSERVE_TYPE_PROP)
       shutterState <- shutterStateObserveType(obsType).asRight

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -31,7 +31,6 @@ import seqexec.server.InstrumentSystem
 import seqexec.server.InstrumentSystem._
 import seqexec.server.Progress
 import seqexec.server.SeqexecFailure
-import seqexec.server.TrySeq
 import seqexec.server.gsaoi.GsaoiController._
 import seqexec.server.keywords.DhsClient
 import seqexec.server.keywords.DhsInstrument
@@ -172,10 +171,10 @@ object Gsaoi {
       fowSamples <- extractNrOfFowSamples(config)
     } yield DCConfig(readMode, roi, coadds, expTime, fowSamples)
 
-  def fromSequenceConfig(config: CleanConfig): TrySeq[GsaoiConfig] =
+  def fromSequenceConfig(config: CleanConfig): Either[SeqexecFailure, GsaoiConfig] =
     for {
-      cc <- readCCConfig(config).asTrySeq
-      dc <- readDCConfig(config).asTrySeq
+      cc <- readCCConfig(config).adaptExtractFailure
+      dc <- readDCConfig(config).adaptExtractFailure
     } yield GsaoiConfig(cc, dc)
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/package.scala
@@ -98,13 +98,6 @@ package object server {
   implicit val sgoEq: Eq[StandardGuideOptions.Value] =
     Eq[Int].contramap(_.ordinal())
 
-  type TrySeq[A]                 = Either[SeqexecFailure, A]
-
-  object TrySeq {
-    def apply[A](a: A): TrySeq[A]              = Either.right(a)
-    def fail[A](p:  SeqexecFailure): TrySeq[A] = Either.left(p)
-  }
-
   type ExecutionQueues = Map[QueueId, ExecutionQueue]
 
   // This is far from ideal but we'll address this in another refactoring


### PR DESCRIPTION
We've been trying  to reduce the use pf type aliases in the seqexec.
This OR removes `TrySeq`