### PR TITLE
Support copying the seqexec version

### DIFF
--- a/modules/seqexec/web/client/src/main/resources/dev.js
+++ b/modules/seqexec/web/client/src/main/resources/dev.js
@@ -1,5 +1,6 @@
 import "./theme/semantic.less";
 import "./less/style.less";
+import "./less/semantic-ui-alerts.less";
 
 var App = require("sjs/seqexec_web_client-fastopt.js");
 

--- a/modules/seqexec/web/client/src/main/resources/less/semantic-ui-alerts.less
+++ b/modules/seqexec/web/client/src/main/resources/less/semantic-ui-alerts.less
@@ -1,0 +1,71 @@
+.ui-alerts {
+    position: fixed;
+    z-index: 2060;
+    padding: 23px;
+}
+
+.ui-alerts.center {
+    top: 50%;
+    left: 50%;
+    margin-top: -100px;
+    margin-left: -222px;
+}
+
+.ui-alerts.top-right {
+    top: 20px;
+    right: 20px;
+}
+
+.ui-alerts.top-center {
+    top: 20px;
+    margin-left: -222px;
+    left: 50%;
+}
+
+.ui-alerts.top-left {
+    top: 20px;
+    left: 20px;
+}
+
+.ui-alerts.bottom-right {
+    bottom: 0;
+    right: 20px;
+}
+.ui-alerts.bottom-center {
+    bottom: 0;
+    margin-left: -222px;
+    left: 50%;
+}
+
+.ui-alerts.bottom-left {
+    bottom: 0;
+    left: 20px;
+}
+
+.ui-alerts.ui-alerts > .message > .content > .header {
+    padding-right: 13px;
+}
+
+@media (min-width: 320px) {
+    /* smartphones, portrait iPhone, portrait 480x320 phones (Android) */
+    .ui-alerts.top-center {
+        margin-left: -163px;
+    }
+}
+@media (min-width: 480px) {
+    /* smartphones, Android phones, landscape iPhone */
+}
+@media (min-width: 600px) {
+    /* portrait tablets, portrait iPad, e-readers (Nook/Kindle), landscape 800x480 phones
+ * (Android) */
+}
+@media (min-width: 801px) {
+    /* tablet, landscape iPad, lo-res laptops ands desktops */
+}
+@media (min-width: 1025px) {
+    /* big landscape tablets, laptops, and desktops */
+}
+@media (min-width: 1281px) {
+    /* hi-res laptops and desktops */
+}
+

--- a/modules/seqexec/web/client/src/main/resources/less/style.less
+++ b/modules/seqexec/web/client/src/main/resources/less/style.less
@@ -1311,6 +1311,10 @@ body {
   cursor: default !important;
 }
 
+.ui-alerts.SeqexecStyles-toast {
+  padding-bottom: 32px;
+}
+
 @media only screen and (max-width: 767px) {
   .SeqexecStyles-notInMobile {
     display: none !important;
@@ -1391,3 +1395,4 @@ body {
     height: ~"calc(100vh - 35.9em)";
   }
 }
+

--- a/modules/seqexec/web/client/src/main/resources/prod.js
+++ b/modules/seqexec/web/client/src/main/resources/prod.js
@@ -1,5 +1,7 @@
 import "./theme/semantic.less";
 import "./less/style.less";
+import "./less/semantic-ui-alerts.less";
+
 var App = require("sjs/seqexec_web_client-opt.js");
 
 App.SeqexecApp.start();

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/DividedProgress.scala
@@ -3,8 +3,9 @@
 
 package seqexec.web.client.components
 
-import cats.implicits._
 import scala.scalajs.js.JSConverters._
+
+import cats.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
@@ -52,7 +52,7 @@ object Footer {
     )
 
   private val component = ScalaComponent
-    .builder[Props]("Footer")
+    .builder[Props]
     .stateless
     .render_P(p =>
       Menu(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
@@ -3,24 +3,33 @@
 
 package seqexec.web.client.components
 
+import scala.concurrent.duration._
+
 import gem.enum.Site
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.vdom.html_<^._
+import react.clipboard.CopyToClipboard
 import react.common._
 import react.semanticui.collections.menu._
+import react.semanticui.elements.icon.Icon
+import react.semanticui.modules.popup.Popup
+import react.semanticui.modules.popup.PopupPosition
+import react.semanticui.sizes._
+import react.semanticui.toasts._
 import seqexec.web.client.OcsBuildInfo
 import seqexec.web.client.actions.SelectCalibrationQueue
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.model.Pages._
 import seqexec.web.client.reusability._
 
-final case class Footer(router: RouterCtl[SeqexecPages], site: Site) extends ReactProps[Footer](Footer.component)
+final case class Footer(router: RouterCtl[SeqexecPages], site: Site)
+    extends ReactProps[Footer](Footer.component)
 
 /**
-  * Component for the bar at the top of the page
-  */
+ * Component for the bar at the top of the page
+ */
 object Footer {
   type Props = Footer
 
@@ -32,31 +41,40 @@ object Footer {
     e.preventDefaultCB *>
       p.router.dispatchAndSetUrlCB(SelectCalibrationQueue)
 
+  val onVersionCopy = (_: String, _: Boolean) =>
+    toastCB(
+      ToastOptions(title = "Copied...",
+                   icon = Icon("clipboard"),
+                   size = Small,
+                   tpe = ToastType.Success,
+                   time = Dismissal.On(500.millisecond)
+      )
+    )
+
   private val component = ScalaComponent
-    .builder[Props]("SeqexecAppBar")
+    .builder[Props]("Footer")
     .stateless
     .render_P(p =>
       Menu(
-        clazz    = Css("footer"),
+        clazz = Css("footer"),
         inverted = true
       )(
         MenuItem(
-          as       = "a",
-          header   = true,
-          clazz    = SeqexecStyles.notInMobile,
+          as = "a",
+          header = true,
+          clazz = SeqexecStyles.notInMobile,
           onClickE = goHome(p) _
         )(s"Seqexec - ${p.site.shortName}"),
-        MenuItem(
-          as       = "a",
-          header   = true,
-          clazz    = SeqexecStyles.onlyMobile,
-          onClickE = goHome(p) _
-        )(p.site.shortName),
-        MenuMenu(
-          MenuItem(
-            header = true,
-            clazz  = SeqexecStyles.notInMobile
-          )(OcsBuildInfo.version)
+        CopyToClipboard(text = OcsBuildInfo.version, onCopy = onVersionCopy)(
+          Popup(
+            position = PopupPosition.TopCenter,
+            size = Tiny,
+            trigger = MenuItem(
+              as = "a",
+              header = true,
+              clazz = SeqexecStyles.notInMobile
+            )(OcsBuildInfo.version)
+          )("Copy to clipboard")
         ),
         userConnect(x => FooterStatus(x()))
       )

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -15,6 +15,7 @@ import react.common._
 import react.common.implicits._
 import react.semanticui.collections.grid._
 import react.semanticui.elements.divider.Divider
+import react.semanticui.toasts._
 import react.semanticui.widths._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.tabs.TabsArea
@@ -22,7 +23,8 @@ import seqexec.web.client.model.Pages._
 import seqexec.web.client.model.WebSocketConnection
 import seqexec.web.client.reusability._
 
-final case class AppTitle(site: Site, ws: WebSocketConnection) extends ReactProps[AppTitle](AppTitle.component)
+final case class AppTitle(site: Site, ws: WebSocketConnection)
+    extends ReactProps[AppTitle](AppTitle.component)
 
 object AppTitle {
   type Props = AppTitle
@@ -33,10 +35,11 @@ object AppTitle {
     .builder[Props]("SeqexecTitle")
     .stateless
     .render_P(p =>
-      Divider(as         = "h4",
+      Divider(as = "h4",
               horizontal = true,
               clazz =
-                SeqexecStyles.titleRow |+| SeqexecStyles.notInMobile |+| SeqexecStyles.header)(
+                SeqexecStyles.titleRow |+| SeqexecStyles.notInMobile |+| SeqexecStyles.header
+      )(
         s"Seqexec ${p.site.shortName}",
         p.ws.ws.renderPending(_ =>
           <.div(
@@ -52,7 +55,8 @@ object AppTitle {
 
 }
 
-final case class SeqexecMain(site: Site, ctl: RouterCtl[SeqexecPages]) extends ReactProps[SeqexecMain](SeqexecMain.component)
+final case class SeqexecMain(site: Site, ctl: RouterCtl[SeqexecPages])
+    extends ReactProps[SeqexecMain](SeqexecMain.component)
 
 object SeqexecMain {
   type Props = SeqexecMain
@@ -70,14 +74,19 @@ object SeqexecMain {
     .stateless
     .render_P(p =>
       React.Fragment(
-        Grid(padded     = GridPadded.Horizontally)(
+        SemanticToastContainer(position = ContainerPosition.BottomRight,
+                               animation = SemanticAnimation.FadeUp,
+                               clazz = SeqexecStyles.Toast
+        ),
+        Grid(padded = GridPadded.Horizontally)(
           GridRow(clazz = SeqexecStyles.shorterRow),
           wsConnect(ws => AppTitle(p.site, ws())),
           GridRow(clazz = SeqexecStyles.shorterRow |+| SeqexecStyles.queueAreaRow)(
-            GridColumn(mobile   = Sixteen,
-                       tablet   = Ten,
+            GridColumn(mobile = Sixteen,
+                       tablet = Ten,
                        computer = Ten,
-                       clazz    = SeqexecStyles.queueArea)(
+                       clazz = SeqexecStyles.queueArea
+            )(
               SessionQueueTableSection(p.ctl)
             ),
             GridColumn(tablet = Six, computer = Six, clazz = SeqexecStyles.headerSideBarArea)(

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -6,8 +6,8 @@ package seqexec.web.client.components
 import react.common.style._
 
 /**
-  * Custom CSS for the Seqexec UI
-  */
+ * Custom CSS for the Seqexec UI
+ */
 object SeqexecStyles {
 
   val headerHeight: Int             = 33
@@ -18,6 +18,9 @@ object SeqexecStyles {
   val TableBorderWidth: Double      = 1.0
   val TableRightPadding: Int        = 13
   val DefaultScrollBarWidth: Double = 15.0
+
+  val Toast: Css =
+    Css("SeqexecStyles-toast")
 
   val tableDetailRow: Css =
     Css("SeqexecStyles-tableDetailRow")


### PR DESCRIPTION
It is not possible now to copy the version of the seqexec from the UI.
We want to make it easier for users to report the version number.
This PR will copy the version when the area is clicked

I also used this as an opportunity to test semantic-ui-toasts for notifications.

![ezgif com-video-to-gif(3)](https://user-images.githubusercontent.com/3615303/92514778-dc5cd700-f1e8-11ea-9dc2-c0bbc5074e47.gif)
