### PR TITLE
SEQNG-1220 Don't use a custom mask if FPU is NONE

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -112,7 +112,7 @@ object Ghost {
           baseRAHMS     <- raExtractor(SPGhost.BASE_RA_HMS)
           baseDecDMS    <- decExtractor(SPGhost.BASE_DEC_DMS)
 
-          fiberAgitator = extractor[Boolean](SPGhost.FIBER_AGITATOR)
+          fiberAgitator = extractor[Boolean](SPGhost.FIBER_AGITATOR_1)
           srifu1Name    = extractor[String](SPGhost.SRIFU1_NAME)
           srifu1RAHMS   <- raExtractor(SPGhost.SRIFU1_RA_HMS)
           srifu1DecHDMS <- decExtractor(SPGhost.SRIFU1_DEC_DMS)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -105,16 +105,26 @@ abstract class Gmos[F[_]: Concurrent: Timer: Logger, T <: GmosController.SiteDep
     else
       nsCmdRef.set(NSObserveCommand.PauseImmediately.some) *> controller.pauseObserve
 
-  protected def fpuFromFPUnit(n: Option[T#FPU], m: Option[String])(fpu: FPUnitMode): GmosFPU = fpu match {
+  protected def fpuFromFPUnit(
+    n: Option[T#FPU],
+    m: Option[String],
+    fpu: FPUnitMode)(implicit eqFPU: Eq[T#FPU]
+  ): GmosFPU = fpu match {
     case FPUnitMode.BUILTIN     => configTypes.BuiltInFPU(n.getOrElse(ss.fpuDefault))
-    case FPUnitMode.CUSTOM_MASK => m match {
-      case Some(u) => GmosController.Config.CustomMaskFPU(u)
-      case _       => GmosController.Config.UnknownFPU
-    }
+    case FPUnitMode.CUSTOM_MASK =>
+      (m, n) match {
+        // if FPU is set to NONE ignore custom mask
+        case (_, Some(x)) if x === ss.fpuDefault => configTypes.BuiltInFPU(ss.fpuDefault)
+        case (Some(u), _)                        => GmosController.Config.CustomMaskFPU(u)
+        case _                                   => GmosController.Config.UnknownFPU
+      }
   }
 
-  private def calcDisperser(disp: T#Disperser, order: Option[DisperserOrder], wl: Option[Length])
-  : Either[ConfigUtilOps.ExtractFailure, configTypes.GmosDisperser] =
+  private def calcDisperser(
+    disp: T#Disperser,
+    order: Option[DisperserOrder],
+    wl: Option[Length]
+  ): Either[ConfigUtilOps.ExtractFailure, configTypes.GmosDisperser] =
     if (configTypes.isMirror(disp)) {
       configTypes.GmosDisperser.Mirror.asRight[ConfigUtilOps.ExtractFailure]
     } else order.map { o =>
@@ -135,7 +145,7 @@ abstract class Gmos[F[_]: Concurrent: Timer: Logger, T <: GmosController.SiteDep
       disperserLambda  =  config.extractInstAs[JDouble](DISPERSER_LAMBDA_PROP).map(_.toDouble.nanometers)
       fpuName          =  ss.extractFPU(config)
       fpuMask          =  config.extractInstAs[String](FPU_MASK_PROP)
-      fpu              <- config.extractInstAs[FPUnitMode](FPU_MODE_PROP).map(fpuFromFPUnit(fpuName.toOption, fpuMask.toOption))
+      fpu              <- config.extractInstAs[FPUnitMode](FPU_MODE_PROP).map(fpuFromFPUnit(fpuName.toOption, fpuMask.toOption, _)(ss.fpuEq))
       stageMode        <- ss.extractStageMode(config)
       dtax             <- config.extractInstAs[DTAX](DTAX_OFFSET_PROP)
       adc              <- config.extractInstAs[ADC](ADC_PROP)
@@ -183,13 +193,14 @@ abstract class Gmos[F[_]: Concurrent: Timer: Logger, T <: GmosController.SiteDep
   override def notifyObserveStart: F[Unit] = Applicative[F].unit
 
   override def configure(config: CleanConfig): F[ConfigResult[F]] =
-    EitherT.fromEither[F](fromSequenceConfig(config))
+    EitherT
+      .fromEither[F](fromSequenceConfig(config))
       .widenRethrowT
       .flatMap(controller.applyConfig)
       .as(ConfigResult(this))
 
   override def calcObserveTime(config: CleanConfig): F[Time] =
-    (Gmos.expTimeF[F](config), Gmos.nsConfigF[F](config)).mapN {(v, ns) =>
+    (Gmos.expTimeF[F](config), Gmos.nsConfigF[F](config)).mapN { (v, ns) =>
       v / ns.exposureDivider.toDouble
     }
 
@@ -205,7 +216,7 @@ object Gmos {
   def rowsToShuffle(stage: NodAndShuffleStage, rows: Int): Int =
     if (stage === StageA) 0 else rows
 
-  trait SiteSpecifics[T<:SiteDependentTypes] {
+  trait SiteSpecifics[T <: SiteDependentTypes] {
     def extractFilter(config: CleanConfig): Either[ExtractFailure, T#Filter]
 
     def extractDisperser(config: CleanConfig): Either[ExtractFailure, T#Disperser]
@@ -215,18 +226,22 @@ object Gmos {
     def extractStageMode(config: CleanConfig): Either[ExtractFailure, T#GmosStageMode]
 
     val fpuDefault: T#FPU
+
+    val fpuEq: Eq[T#FPU]
   }
 
   val NSKey: ItemKey = INSTRUMENT_KEY / USE_NS_PROP
 
   def isNodAndShuffle(config: CleanConfig): Boolean =
-    config.extractAs[java.lang.Boolean](NSKey)
+    config
+      .extractAs[java.lang.Boolean](NSKey)
       .map(_.booleanValue())
       .getOrElse(false)
 
   def ccElectronicOffset(config: CleanConfig): ElectronicOffset =
     ElectronicOffset.fromBoolean(
-      config.extractInstAs[java.lang.Boolean](USE_ELECTRONIC_OFFSETTING_PROP)
+      config
+        .extractInstAs[java.lang.Boolean](USE_ELECTRONIC_OFFSETTING_PROP)
         .map(_.booleanValue())
         .getOrElse(false) // We should always set electronic offset to false unless explicitly enabled
     )
@@ -276,7 +291,8 @@ object Gmos {
       )
 
   def expTime(config: CleanConfig): Time =
-    config.extractObsAs[JDouble](EXPOSURE_TIME_PROP)
+    config
+      .extractObsAs[JDouble](EXPOSURE_TIME_PROP)
       .map(v => Seconds(v.toDouble))
       .getOrElse(Seconds(10000))
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -5,7 +5,6 @@ package seqexec.server.gmos
 
 import scala.concurrent.duration.Duration
 
-import cats.Eq
 import cats.Show
 import cats.syntax.all._
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.BuiltinROI
@@ -212,8 +211,6 @@ object GmosController {
     type FPU
     type GmosStageMode
     type Disperser
-
-    val disperserEq: Eq[Disperser]
   }
 
   final class SouthTypes extends SiteDependentTypes {
@@ -221,8 +218,6 @@ object GmosController {
     override type FPU           = edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth
     override type GmosStageMode = edu.gemini.spModel.gemini.gmos.GmosSouthType.StageModeSouth
     override type Disperser     = edu.gemini.spModel.gemini.gmos.GmosSouthType.DisperserSouth
-
-    override val disperserEq: Eq[GmosSouthType.DisperserSouth] = Eq.fromUniversalEquals
   }
 
   final class SouthConfigTypes extends Config[SouthTypes] {
@@ -236,8 +231,6 @@ object GmosController {
     override type FPU           = edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth
     override type GmosStageMode = edu.gemini.spModel.gemini.gmos.GmosNorthType.StageModeNorth
     override type Disperser     = edu.gemini.spModel.gemini.gmos.GmosNorthType.DisperserNorth
-
-    override val disperserEq: Eq[GmosNorthType.DisperserNorth] = Eq.fromUniversalEquals
   }
 
   final class NorthConfigTypes extends Config[NorthTypes] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosController.scala
@@ -237,6 +237,7 @@ object GmosController {
     override val mirror = edu.gemini.spModel.gemini.gmos.GmosNorthType.DisperserNorth.MIRROR
     override def isMirror(v: GmosNorthType.DisperserNorth): Boolean = v === mirror
   }
+
   val northConfigTypes: NorthConfigTypes = new NorthConfigTypes
 
   // This is a trick to allow using a type from a class parameter to define the type of another class parameter

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -3,6 +3,7 @@
 
 package seqexec.server.gmos
 
+import cats.Eq
 import cats.effect.Concurrent
 import cats.effect.Timer
 import cats.effect.concurrent.Ref
@@ -32,15 +33,16 @@ final case class GmosNorth[F[_]: Concurrent: Timer: Logger] private (
   nsCmdR: Ref[F, Option[NSObserveCommand]]
 ) extends Gmos[F, NorthTypes](c,
   new SiteSpecifics[NorthTypes] {
-    override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
+    def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
       config.extractInstAs[NorthTypes#Filter](FILTER_PROP)
-    override def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] =
+    def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] =
       config.extractInstAs[NorthTypes#Disperser](DISPERSER_PROP)
-    override def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] =
+    def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] =
       config.extractInstAs[NorthTypes#FPU](FPU_PROP_NAME)
-    override def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
+    def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
       config.extractInstAs[NorthTypes#GmosStageMode](STAGE_MODE_PROP)
-    override val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
+    val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
+    val fpuEq: Eq[GmosNorthType.FPUnitNorth] = Eq.fromUniversalEquals
   },
   nsCmdR
 )(northConfigTypes) {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.gmos
 
-import cats.Eq
 import cats.effect.Concurrent
 import cats.effect.Timer
 import cats.effect.concurrent.Ref
@@ -42,7 +41,7 @@ final case class GmosNorth[F[_]: Concurrent: Timer: Logger] private (
     def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
       config.extractInstAs[NorthTypes#GmosStageMode](STAGE_MODE_PROP)
     val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
-    val fpuEq: Eq[GmosNorthType.FPUnitNorth] = Eq.fromUniversalEquals
+    def isCustomFPU(config: CleanConfig): Boolean = extractFPU(config).map(_.isCustom()).getOrElse(false)
   },
   nsCmdR
 )(northConfigTypes) {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -3,7 +3,6 @@
 
 package seqexec.server.gmos
 
-import cats.Eq
 import cats.effect.Concurrent
 import cats.effect.Timer
 import cats.effect.concurrent.Ref
@@ -34,7 +33,6 @@ final case class GmosSouth[F[_]: Concurrent: Timer: Logger] private (
 ) extends Gmos[F, SouthTypes](
   c,
   new SiteSpecifics[SouthTypes] {
-    val fpuEq: Eq[GmosSouthType.FPUnitSouth] = Eq.fromUniversalEquals
     val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
     def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
       config.extractInstAs[SouthTypes#Filter](FILTER_PROP)
@@ -44,6 +42,7 @@ final case class GmosSouth[F[_]: Concurrent: Timer: Logger] private (
       config.extractInstAs[SouthTypes#FPU](FPU_PROP_NAME)
     def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
       config.extractInstAs[SouthTypes#GmosStageMode](STAGE_MODE_PROP)
+    def isCustomFPU(config: CleanConfig): Boolean = extractFPU(config).map(_.isCustom()).getOrElse(false)
   },
   nsCmdR
 )(southConfigTypes) {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -3,6 +3,7 @@
 
 package seqexec.server.gmos
 
+import cats.Eq
 import cats.effect.Concurrent
 import cats.effect.Timer
 import cats.effect.concurrent.Ref
@@ -33,14 +34,15 @@ final case class GmosSouth[F[_]: Concurrent: Timer: Logger] private (
 ) extends Gmos[F, SouthTypes](
   c,
   new SiteSpecifics[SouthTypes] {
-    override val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
-    override def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
+    val fpuEq: Eq[GmosSouthType.FPUnitSouth] = Eq.fromUniversalEquals
+    val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
+    def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
       config.extractInstAs[SouthTypes#Filter](FILTER_PROP)
-    override def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] =
+    def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] =
       config.extractInstAs[SouthTypes#Disperser](DISPERSER_PROP)
-    override def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] =
+    def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] =
       config.extractInstAs[SouthTypes#FPU](FPU_PROP_NAME)
-    override def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
+    def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
       config.extractInstAs[SouthTypes#GmosStageMode](STAGE_MODE_PROP)
   },
   nsCmdR

--- a/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
+++ b/modules/seqexec/web/client/src/main/scala/seqexec/web/client/model/StepItems.scala
@@ -46,9 +46,7 @@ object StepItems {
       case Instrument.GmosS => enumerations.fpu.GmosSFPU.get
       case Instrument.GmosN => enumerations.fpu.GmosNFPU.get
       case Instrument.F2    => enumerations.fpu.Flamingos2.get
-      case _                =>
-        _ =>
-          none
+      case _                => _ => none
     }
 
     def exposureTime: Option[Double] = observeExposureTimeO.getOption(s)
@@ -63,12 +61,19 @@ object StepItems {
         case _                               => none
       }
     def coAdds: Option[Int] = observeCoaddsO.getOption(s)
+
+    def isNoneFPU(i: Instrument): Boolean =
+      (i, instrumentFPUO.getOption(s)) match {
+        case (Instrument.GmosS | Instrument.GmosN | Instrument.F2, Some("FPU_NONE")) => true
+        case _ => false
+      }
+
     def fpu(i: Instrument): Option[String] =
       for {
         mode <- instrumentFPUModeO
           .getOption(s)
           .orElse(FPUMode.BuiltIn.some) // If the instrument has no fpu mode default to built in
-        fpuL = if (mode === FPUMode.BuiltIn) instrumentFPUO
+        fpuL = if (isNoneFPU(i) || mode === FPUMode.BuiltIn) instrumentFPUO
         else instrumentFPUCustomMaskO
         fpu <- fpuL.getOption(s)
       } yield fpuNameMapper(i)(fpu).getOrElse(fpu)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -56,7 +56,7 @@ object Settings {
 
     // Pure JS libraries
     val semanticUI = "2.3.1"
-    val ocsVersion = "2020001.1.3"
+    val ocsVersion = "2020001.1.4"
 
     val apacheXMLRPC        = "3.1.3"
     val opencsv             = "2.1"


### PR DESCRIPTION
A fault was reported for a GMOS sequence containing a custom mask for some steps and FPU none for others.
The expected behavior is to set custom or no on the respective steps but the seqexec
is trying to set the custom mask at each step

The root cause is that the OT indicates that each step uses a custom mask mode, and that indication
is used to select the mask.
Ideally this would be fixed in the OT but otherwise we can workaround checking the particular case that FPU is none for custom mask mode.

The change is required both in the backend and the frontend as we don't have real types at that level on the frontend, relying instead on the String representation provided by the OT.

The UI shows the difference
Before:
![image (9)](https://user-images.githubusercontent.com/3615303/92830550-cba88e80-f3ab-11ea-8eea-e0c4908816ae.png)

After:
![image (7)](https://user-images.githubusercontent.com/3615303/92830596-d82ce700-f3ab-11ea-936d-9fad05d06e22.png)
 
It require testing against a few sequences