### PR TITLE
Fix to read FPU in some composite cases

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -34,18 +34,23 @@ final case class GmosNorth[F[_]: Concurrent: Timer: Logger] private (
   new SiteSpecifics[NorthTypes] {
     def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, NorthTypes#Filter] =
       config.extractInstAs[NorthTypes#Filter](FILTER_PROP)
+
     def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.DisperserNorth] =
       config.extractInstAs[NorthTypes#Disperser](DISPERSER_PROP)
+
     def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.FPUnitNorth] =
       config.extractInstAs[NorthTypes#FPU](FPU_PROP_NAME)
+
     def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosNorthType.StageModeNorth] =
       config.extractInstAs[NorthTypes#GmosStageMode](STAGE_MODE_PROP)
+
     val fpuDefault: GmosNorthType.FPUnitNorth = FPU_NONE
+
     def isCustomFPU(config: CleanConfig): Boolean =
       (extractFPU(config), extractCustomFPU(config)) match {
-        case (Right(builtIn), _) if builtIn.isCustom() => true
-        case (_, Right(_))                             => true
-        case _                                         => false
+        case (Right(builtIn), Right(_)) => builtIn.isCustom
+        case (_, Right(_))              => true
+        case _                          => false
       }
   },
   nsCmdR

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -34,19 +34,24 @@ final case class GmosSouth[F[_]: Concurrent: Timer: Logger] private (
   c,
   new SiteSpecifics[SouthTypes] {
     val fpuDefault: GmosSouthType.FPUnitSouth = FPU_NONE
+
     def extractFilter(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, SouthTypes#Filter] =
       config.extractInstAs[SouthTypes#Filter](FILTER_PROP)
+
     def extractDisperser(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.DisperserSouth] =
       config.extractInstAs[SouthTypes#Disperser](DISPERSER_PROP)
+
     def extractFPU(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.FPUnitSouth] =
       config.extractInstAs[SouthTypes#FPU](FPU_PROP_NAME)
+
     def extractStageMode(config: CleanConfig): Either[ConfigUtilOps.ExtractFailure, GmosSouthType.StageModeSouth] =
       config.extractInstAs[SouthTypes#GmosStageMode](STAGE_MODE_PROP)
+
     def isCustomFPU(config: CleanConfig): Boolean =
       (extractFPU(config), extractCustomFPU(config)) match {
-        case (Right(builtIn), _) if builtIn.isCustom() => true
-        case (_, Right(_))                             => true
-        case _                                         => false
+        case (Right(builtIn), Right(_)) => builtIn.isCustom
+        case (_, Right(_))              => true
+        case _                          => false
       }
   },
   nsCmdR


### PR DESCRIPTION
This is another attempt to properly read from the OT when to use the built in FPU mask or a custom mask
All provided sample sequences work as expected