### PR TITLE
SEQNG-1224 Use order 0 when GMOS is missing the disperser order parameter

### DIFF
--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -124,16 +124,16 @@ abstract class Gmos[F[_]: Concurrent: Timer: Logger, T <: GmosController.SiteDep
     wl:    Option[Length]
   ): Either[ConfigUtilOps.ExtractFailure, configTypes.GmosDisperser] =
     if (configTypes.isMirror(disp)) {
-      configTypes.GmosDisperser.Mirror.asRight[ConfigUtilOps.ExtractFailure]
+      configTypes.GmosDisperser.Mirror.asRight
     } else order.map { o =>
       if(o === GmosCommonType.Order.ZERO)
-        configTypes.GmosDisperser.Order0(disp).asRight[ConfigUtilOps.ExtractFailure]
+        configTypes.GmosDisperser.Order0(disp).asRight
       else wl.map(w => configTypes.GmosDisperser.OrderN(disp, o, w)
         .asRight[ConfigUtilOps.ExtractFailure]).getOrElse(
           ConfigUtilOps.ContentError(s"Disperser order ${o.displayValue} is missing a wavelength.")
           .asLeft
         )
-    }.getOrElse(ConfigUtilOps.ContentError(s"Disperser is missing an order.").asLeft)
+    }.getOrElse(configTypes.GmosDisperser.Order0(disp).asRight)
 
   private def ccConfigFromSequenceConfig(config: CleanConfig): Either[SeqexecFailure, configTypes.CCConfig] =
     (for {


### PR DESCRIPTION
It happens that a missing Disperser Order in a GMOS sequence was not an error, but a "feature".