### PR TITLE
SEQNG-1224 Changed default for GMOS disperser order to 1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ project/hydra.sbt
 .cache
 .history
 .lib/
+.bsp
 dist/*
 target/
 lib_managed/


### PR DESCRIPTION
After discussing it with Science, we decided to use Order 1 as the default value for GMOS. that will be used when the sequence is using a grating but missing its order. Order 1 requires `disperserWavelength`. Its absence will still be treated as an error.