### PR TITLE
System override implemented on server side.

### DIFF
--- a/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/seqexec/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -83,7 +83,7 @@ class Engine[F[_]: MonadError[?[_], Throwable]: Logger, S, U](stateL: Engine.Sta
     val x = for {
       seq <- stateL.sequenceStateIndex(c.sid).getOption(st)
       if (seq.status.isIdle || seq.status.isError) && !seq.getSingleState(c.actCoords).active
-      act <- seq.getSingleAction(c.actCoords)
+      act <- seq.rollback.getSingleAction(c.actCoords)
     } yield act.gen
 
     x.map(p =>

--- a/modules/seqexec/server/src/main/scala/seqexec/server/FileIdProvider.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/FileIdProvider.scala
@@ -10,7 +10,7 @@ object FileIdProvider {
 
   def fileId[F[_]](env: ObserveEnvironment[F]): F[ImageFileId] =
     // All instruments ask the DHS for an ImageFileId
-    env.systems.dhs.createImage(
+    env.dhs.createImage(
       DhsClient.ImageParameters(DhsClient.Permanent,
                                 List(env.inst.contributorName, "dhs-http"))
     )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
@@ -1,0 +1,11 @@
+package seqexec.server
+
+import seqexec.model.enum.Instrument
+
+trait InstrumentSpecifics {
+  val instrument: Instrument
+
+  def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
+    SequenceConfiguration.calcStepType(config, isNightSeq)
+
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server
 
 import lucuma.core.enum.LightSinkName

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
@@ -1,6 +1,6 @@
 package seqexec.server
 
-import gem.`enum`.LightSinkName
+import lucuma.core.enum.LightSinkName
 import squants.Length
 
 trait InstrumentSpecifics extends InstrumentGuide {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
@@ -1,11 +1,15 @@
 package seqexec.server
 
-import seqexec.model.enum.Instrument
+import gem.`enum`.LightSinkName
+import squants.Length
 
-trait InstrumentSpecifics {
-  val instrument: Instrument
-
+trait InstrumentSpecifics extends InstrumentGuide {
   def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
     SequenceConfiguration.calcStepType(config, isNightSeq)
+
+  override val oiOffsetGuideThreshold: Option[Length] = None
+
+  // The name used for this instrument in the science fold configuration
+  def sfName(config: CleanConfig): LightSinkName
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -7,18 +7,15 @@ import scala.concurrent.duration._
 
 import cats.data.Kleisli
 import fs2.Stream
-import lucuma.core.enum.LightSinkName
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.keywords.KeywordsClient
-import squants.Length
 import squants.Time
 
-trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
+trait InstrumentSystem[F[_]] extends System[F] {
   override val resource: Instrument
-  // The name used for this instrument in the science fold configuration
-  def sfName(config: CleanConfig): LightSinkName
+
   val contributorName: String
 
   def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F]
@@ -35,10 +32,6 @@ trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
   def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress]
 
   def instrumentActions(config: CleanConfig): InstrumentActions[F]
-
-  override val oiOffsetGuideThreshold: Option[Length] = None
-
-  override def instrument: Instrument = resource
 
 }
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -36,9 +36,6 @@ trait InstrumentSystem[F[_]] extends System[F] with InstrumentGuide {
 
   def instrumentActions(config: CleanConfig): InstrumentActions[F]
 
-  def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
-    SequenceConfiguration.calcStepType(config, isNightSeq)
-
   override val oiOffsetGuideThreshold: Option[Length] = None
 
   override def instrument: Instrument = resource

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
@@ -109,9 +109,10 @@ object ODBSequencesLoader {
 
   private def toEngineSequence[F[_]](
     id:  Observation.Id,
+    overrides: SystemOverrides,
     seq: SequenceGen[F],
     d:   HeaderExtraData
-  ): Sequence[F] = Sequence(id, toStepList(seq, d))
+  ): Sequence[F] = Sequence(id, toStepList(seq, overrides, d))
 
   private[server] def loadSequenceEndo[F[_]: MonadError[?[_], Throwable]: Logger](
     seqId: Observation.Id,
@@ -123,10 +124,12 @@ object ODBSequencesLoader {
         ss =>
           ss + (seqId -> SequenceData[F](
             None,
+            SystemOverrides.allEnabled,
             seqg,
             execEngine.load(
               toEngineSequence(
                 seqId,
+                SystemOverrides.allEnabled,
                 seqg,
                 HeaderExtraData(st.conditions, st.operator, None)
               )
@@ -151,6 +154,11 @@ object ODBSequencesLoader {
                 sd.seq,
                 toStepList(
                   seqg,
-                  HeaderExtraData(st.conditions, st.operator, sd.observer)))))(st)
+                  sd.overrides,
+                  HeaderExtraData(st.conditions, st.operator, sd.observer)
+                )
+              )
+            )
+        )(st)
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ODBSequencesLoader.scala
@@ -124,12 +124,12 @@ object ODBSequencesLoader {
         ss =>
           ss + (seqId -> SequenceData[F](
             None,
-            SystemOverrides.allEnabled,
+            SystemOverrides.AllEnabled,
             seqg,
             execEngine.load(
               toEngineSequence(
                 seqId,
-                SystemOverrides.allEnabled,
+                SystemOverrides.AllEnabled,
                 seqg,
                 HeaderExtraData(st.conditions, st.operator, None)
               )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveActions.scala
@@ -135,7 +135,7 @@ trait ObserveActions {
       _ <- notifyObserveEnd(env)
       _ <- env.headers(env.ctx).reverseIterator.toList.traverse(_.sendAfter(fileId))
       _ <- closeImage(fileId, env)
-      _ <- sendDataEnd[F](env.odb, env.obsId, fileId, env.dataId)
+      _ <- sendDataEnd(env.odb, env.obsId, fileId, env.dataId)
     } yield
       if (stopped) Result.OKStopped(Response.Observed(fileId))
       else Result.OK(Response.Observed(fileId))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
@@ -12,12 +12,14 @@ import seqexec.server.tcs.Tcs
   * Describes the parameters for an observation
   */
 final case class ObserveEnvironment[F[_]](
-  systems:  Systems[F],
+  odb:      OdbProxy[F],
+  dhs:      DhsClient[F],
   config:   CleanConfig,
   stepType: StepType,
   obsId:    Observation.Id,
   dataId:   DataId,
   inst:     InstrumentSystem[F],
+  insSpecs: InstrumentSpecifics,
   otherSys: List[System[F]],
   headers:  HeaderExtraData => List[Header[F]],
   ctx:      HeaderExtraData

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SeqEvent.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SeqEvent.scala
@@ -20,6 +20,10 @@ sealed trait SeqEvent extends Product with Serializable
 object SeqEvent {
   final case class SetOperator(name: Operator, user: Option[UserDetails]) extends SeqEvent
   final case class SetObserver(id: Observation.Id, user: Option[UserDetails], name: Observer) extends SeqEvent
+  final case class SetTcsEnabled(id: Observation.Id, user: Option[UserDetails], enabled: Boolean) extends SeqEvent
+  final case class SetGcalEnabled(id: Observation.Id, user: Option[UserDetails], enabled: Boolean) extends SeqEvent
+  final case class SetInstrumentEnabled(id: Observation.Id, user: Option[UserDetails], enabled: Boolean) extends SeqEvent
+  final case class SetDhsEnabled(id: Observation.Id, user: Option[UserDetails], enabled: Boolean) extends SeqEvent
   final case class SetConditions(conditions: Conditions, user: Option[UserDetails]) extends SeqEvent
   final case class LoadSequence(sid: Observation.Id) extends SeqEvent
   final case class UnloadSequence(id: Observation.Id) extends SeqEvent

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SequenceData.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SequenceData.scala
@@ -10,6 +10,7 @@ import seqexec.model.Observer
 
 @Lenses
 final case class SequenceData[F[_]](observer: Option[Observer],
+                                    overrides: SystemOverrides,
                                     seqGen: SequenceGen[F],
                                     seq: Sequence.State[F],
                                     pendingObsCmd: Option[PendingObserveCmd])

--- a/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/StepType.scala
@@ -13,7 +13,6 @@ sealed trait StepType {
 
 object StepType {
   final case class CelestialObject(override val instrument: Instrument) extends StepType
-  final case class Dark(override val instrument: Instrument) extends StepType
   final case class NodAndShuffle(override val instrument: Instrument) extends StepType
   final case class Gems(override val instrument: Instrument) extends StepType
   final case class AltairObs(override val instrument: Instrument) extends StepType
@@ -30,7 +29,6 @@ object StepType {
 
   implicit val eqStepType: Eq[StepType] = Eq.instance {
     case (CelestialObject(i), CelestialObject(j))         => i === j
-    case (Dark(i), Dark(j))                               => i === j
     case (NodAndShuffle(i), NodAndShuffle(j))             => i === j
     case (Gems(i), Gems(j))                               => i === j
     case (AltairObs(i), AltairObs(j))                     => i === j

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SystemOverrides.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SystemOverrides.scala
@@ -21,7 +21,7 @@ trait SystemOverrides {
 }
 
 object SystemOverrides {
-  val allEnabled: SystemOverrides = SystemOverridesImpl(
+  val AllEnabled: SystemOverrides = SystemOverridesImpl(
     isTcsEnabled = true,
     isInstrumentEnabled = true,
     isGcalEnabled = true,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SystemOverrides.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SystemOverrides.scala
@@ -1,0 +1,52 @@
+package seqexec.server
+
+import io.chrisdavenport.log4cats.Logger
+
+trait SystemOverrides {
+  val isTcsEnabled: Boolean
+  val isInstrumentEnabled: Boolean
+  val isGcalEnabled: Boolean
+  val isDhsEnabled: Boolean
+  def disableTcs: SystemOverrides
+  def enableTcs: SystemOverrides
+  def disableInstrument: SystemOverrides
+  def enableInstrument: SystemOverrides
+  def disableGcal: SystemOverrides
+  def enableGcal: SystemOverrides
+  def disableDhs: SystemOverrides
+  def enableDhs: SystemOverrides
+}
+
+object SystemOverrides {
+  val allEnabled: SystemOverrides = SystemOverridesImpl(
+    isTcsEnabled = true,
+    isInstrumentEnabled = true,
+    isGcalEnabled = true,
+    isDhsEnabled = true
+  )
+
+  private case class SystemOverridesImpl(override val isTcsEnabled: Boolean,
+                                         override val isInstrumentEnabled: Boolean,
+                                         override val isGcalEnabled: Boolean,
+                                         override val isDhsEnabled: Boolean
+  ) extends SystemOverrides {
+    override def disableTcs: SystemOverrides = copy(isTcsEnabled = false)
+
+    override def enableTcs: SystemOverrides = copy(isTcsEnabled = true)
+
+    override def disableInstrument: SystemOverrides = copy(isInstrumentEnabled = false)
+
+    override def enableInstrument: SystemOverrides = copy(isInstrumentEnabled = true)
+
+    override def disableGcal: SystemOverrides = copy(isGcalEnabled = false)
+
+    override def enableGcal: SystemOverrides = copy(isGcalEnabled = true)
+
+    override def disableDhs: SystemOverrides = copy(isDhsEnabled = false)
+
+    override def enableDhs: SystemOverrides = copy(isDhsEnabled = true)
+  }
+
+  def overrideLogMessage[F[_]: Logger](systemName: String, op: String): F[Unit] =
+    Logger[F].info(s"System $systemName overridden. Operation $op skipped.")
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/SystemOverrides.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/SystemOverrides.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server
 
 import io.chrisdavenport.log4cats.Logger

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/Altair.scala
@@ -5,7 +5,6 @@ package seqexec.server.altair
 
 import cats.ApplicativeError
 import cats.effect.Sync
-import cats.syntax.all._
 import edu.gemini.spModel.gemini.altair.AltairConstants.FIELD_LENSE_PROP
 import edu.gemini.spModel.gemini.altair.AltairConstants.GUIDESTAR_TYPE_PROP
 import edu.gemini.spModel.gemini.altair.AltairParams.GuideStarType
@@ -76,12 +75,12 @@ object Altair {
 
   }
 
-  def fromConfig[F[_]: Sync](config: CleanConfig, controller: AltairController[F]): F[Altair[F]] =
-    config.extractAOAs[FieldLens](FIELD_LENSE_PROP).map { fieldLens =>
-      new AltairImpl[F](controller, fieldLens)
-    }.toF[F].widen[Altair[F]]
+  def fromConfig[F[_]: Sync](config: CleanConfig): F[AltairController[F] => Altair[F]] =
+    config.extractAOAs[FieldLens](FIELD_LENSE_PROP).map { fieldLens => (controller: AltairController[F]) =>
+      new AltairImpl[F](controller, fieldLens):Altair[F]
+    }.toF[F]
 
-  def guideStarType[F[_]: ApplicativeError[?[_], Throwable]](config: CleanConfig): F[GuideStarType] =
+  def guideStarType[F[_]: ApplicativeError[*[_], Throwable]](config: CleanConfig): F[GuideStarType] =
     config.extractAOAs[GuideStarType](GUIDESTAR_TYPE_PROP).toF[F]
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerDisabled.scala
@@ -1,0 +1,29 @@
+package seqexec.server.altair
+
+import cats.Applicative
+import io.chrisdavenport.log4cats.Logger
+import cats.implicits._
+import seqexec.server.SystemOverrides.overrideLogMessage
+import seqexec.server.altair.AltairController.FieldLens
+import seqexec.server.tcs.Gaos
+import seqexec.server.tcs.Gaos.PauseResume
+import squants.Time
+
+class AltairControllerDisabled[F[_]: Logger: Applicative] extends AltairController[F] {
+  override def pauseResume(pauseReasons: Gaos.PauseConditionSet,
+                           resumeReasons: Gaos.ResumeConditionSet,
+                           fieldLens: FieldLens
+                          )(cfg: AltairController.AltairConfig): F[Gaos.PauseResume[F]] =
+    PauseResume(
+      overrideLogMessage("Altair", "pause AO loops").some,
+      overrideLogMessage("Altair", "resume AO loops").some
+    ).pure[F]
+
+  override def observe(expTime: Time)(cfg: AltairController.AltairConfig): F[Unit] =
+    overrideLogMessage("Altair", "observe")
+
+  override def endObserve(cfg: AltairController.AltairConfig): F[Unit] =
+    overrideLogMessage("Altair", "endObserve")
+
+  override def isFollowing: F[Boolean] = false.pure[F]
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.altair
 
 import cats.Applicative

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairHeader.scala
@@ -10,20 +10,19 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 import seqexec.server.tcs.CRFollow
 import seqexec.server.tcs.TcsKeywordsReader
 
 object AltairHeader {
-  def header[F[_]: Sync: Logger](inst:              InstrumentSystem[F],
+  def header[F[_]: Sync: Logger](kwClient:  KeywordsClient[F],
                          altairReader:      AltairKeywordReader[F],
                          tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] =
     new Header[F] {
       override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
         sendKeywords(
           id,
-          inst,
+          kwClient,
           List(
             buildDouble(altairReader.aofreq, KeywordName.AOFREQ),
             buildDouble(altairReader.aocounts, KeywordName.AOCOUNTS),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairLgsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/altair/AltairLgsHeader.scala
@@ -9,18 +9,17 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 
 object AltairLgsHeader {
 
-  def header[F[_]: Sync: Logger](inst: InstrumentSystem[F], altairReader: AltairKeywordReader[F]): Header[F] =
+  def header[F[_]: Sync: Logger](kwClient: KeywordsClient[F], altairReader: AltairKeywordReader[F]): Header[F] =
     new Header[F] {
 
       override def sendAfter(id: ImageFileId): F[Unit] =
         sendKeywords(
           id,
-          inst,
+          kwClient,
           List(
             buildDouble(altairReader.lgdfocus, KeywordName.LGDFOCUS),
             buildDouble(altairReader.lgttcnts, KeywordName.LGTTCNTS),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -184,10 +184,13 @@ object Flamingos2 {
       s <- config.extractInstAs[Decker](DECKER_PROP)
     } yield DCConfig(p, q, r, s)).leftMap(e => SeqexecFailure.Unexpected(ConfigUtilOps.explain(e)))
 
-  def fromSequenceConfig[F[_]: Sync](config: CleanConfig): Either[SeqexecFailure, Flamingos2Config] = ( for {
+  def fromSequenceConfig[F[_]: Sync](config: CleanConfig): Either[SeqexecFailure, Flamingos2Config] = for {
       p <- ccConfigFromSequenceConfig(config)
       q <- dcConfigFromSequenceConfig(config)
     } yield Flamingos2Config(p, q)
-   )
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.F2
+  }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -47,8 +47,6 @@ final case class Flamingos2[F[_]: Timer: Logger: Concurrent](
 
   override val resource: Instrument = Instrument.F2
 
-  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.F2
-
   override val contributorName: String = "flamingos2"
 
   override val dhsInstrumentName: String = "F2"
@@ -87,9 +85,6 @@ final case class Flamingos2[F[_]: Timer: Logger: Concurrent](
   override def instrumentActions(config: CleanConfig): InstrumentActions[F] =
     InstrumentActions.defaultInstrumentActions[F]
 
-  // TODO Use different value if using electronic offsets
-  override val oiOffsetGuideThreshold: Option[Length] =
-    (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 }
 
 object Flamingos2 {
@@ -191,6 +186,13 @@ object Flamingos2 {
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.F2
+
+    // TODO Use different value if using electronic offsets
+    override val oiOffsetGuideThreshold: Option[Length] =
+      (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.F2
+
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerDisabled.scala
@@ -1,0 +1,23 @@
+package seqexec.server.flamingos2
+
+import cats.Functor
+import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
+import fs2.Stream
+import seqexec.model.`enum`.ObserveCommandResult
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.Progress
+import seqexec.server.SystemOverrides.overrideLogMessage
+import squants.Time
+
+class Flamingos2ControllerDisabled[F[_]: Logger: Functor] extends Flamingos2Controller[F] {
+  override def applyConfig(config: Flamingos2Controller.Flamingos2Config): F[Unit] =
+    overrideLogMessage("Flamingos-2", "applyConfig")
+
+  override def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult] =
+    overrideLogMessage("Flamingos-2", s"observe $fileId").as(ObserveCommandResult.Success)
+
+  override def endObserve: F[Unit] = overrideLogMessage("FLAMINGOS-2", "endObserve")
+
+  override def observeProgress(total: Time): Stream[F, Progress] = Stream.empty
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.flamingos2
 
 import cats.Functor

--- a/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/flamingos2/Flamingos2Header.scala
@@ -22,20 +22,19 @@ import seqexec.server.CleanConfig
 import seqexec.server.CleanConfig.extractItem
 import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.InstrumentSystem
 import seqexec.server.SeqexecFailure
 import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
 
 object Flamingos2Header {
-  def header[F[_]: Sync: Logger](inst:              InstrumentSystem[F],
+  def header[F[_]: Sync: Logger](kwClient:  KeywordsClient[F],
                          f2ObsReader:       Flamingos2Header.ObsKeywordsReader[F],
                          tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] =
     new Header[F] {
       override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
         sendKeywords(
           id,
-          inst,
+          kwClient,
           List(
             buildBoolean(f2ObsReader.preimage, KeywordName.PREIMAGE, DefaultHeaderValue.FalseDefaultValue),
             buildString(

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerDisabled.scala
@@ -1,0 +1,8 @@
+package seqexec.server.gcal
+
+import io.chrisdavenport.log4cats.Logger
+import seqexec.server.SystemOverrides.overrideLogMessage
+
+class GcalControllerDisabled[F[_]: Logger] extends GcalController[F] {
+  override def applyConfig(config: GcalController.GcalConfig): F[Unit] = overrideLogMessage("GCAL", "applyConfig")
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.gcal
 
 import io.chrisdavenport.log4cats.Logger

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gcal/GcalHeader.scala
@@ -9,11 +9,10 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 
 object GcalHeader {
-  implicit def header[F[_]: Sync: Logger](inst: InstrumentSystem[F], gcalReader: GcalKeywordReader[F]): Header[F] =
+  implicit def header[F[_]: Sync: Logger](kwClient: KeywordsClient[F], gcalReader: GcalKeywordReader[F]): Header[F] =
     new Header[F] {
       private val gcalKeywords = List(
         buildString(gcalReader.lamp, KeywordName.GCALLAMP),
@@ -24,7 +23,7 @@ object GcalHeader {
 
       override def sendBefore(obsId: Observation.Id,
                               id: ImageFileId): F[Unit] =
-        sendKeywords(id, inst, gcalKeywords)
+        sendKeywords(id, kwClient, gcalKeywords)
 
       override def sendAfter(id: ImageFileId): F[Unit] = Applicative[F].unit
     }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerDisabled.scala
@@ -1,0 +1,21 @@
+package seqexec.server.gems
+
+import seqexec.server.gems.Gems.GemsWfsState
+import cats.implicits._
+import cats.Applicative
+import io.chrisdavenport.log4cats.Logger
+import seqexec.server.SystemOverrides.overrideLogMessage
+import seqexec.server.tcs.Gaos
+import seqexec.server.tcs.Gaos.PauseResume
+
+class GemsControllerDisabled[F[_]: Logger: Applicative] extends GemsController[F] {
+  override def pauseResume(pauseReasons: Gaos.PauseConditionSet,
+                           resumeReasons: Gaos.ResumeConditionSet
+                          )(cfg: GemsController.GemsConfig): F[Gaos.PauseResume[F]] =
+    PauseResume(
+      overrideLogMessage("GeMS", "pause AO loops").some,
+      overrideLogMessage("GeMS", "resume AO loops").some
+    ).pure[F]
+
+  override val stateGetter: GemsWfsState[F] = GemsWfsState.allOff
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gems/GemsControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.gems
 
 import seqexec.server.gems.Gems.GemsWfsState

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -43,8 +43,6 @@ final case class Ghost[F[_]: Logger: Concurrent: Timer](controller: GhostControl
 
   override val resource: Instrument = Instrument.Ghost
 
-  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Ghost
-
   override val contributorName: String = "ghost"
 
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
@@ -145,5 +143,8 @@ object Ghost {
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.Ghost
+
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Ghost
+
   }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -142,4 +142,8 @@ object Ghost {
       }
     }.widenRethrowT
   }
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.Ghost
+  }
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.ghost
 
 import cats.Applicative

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostControllerDisabled.scala
@@ -1,0 +1,29 @@
+package seqexec.server.ghost
+
+import cats.Applicative
+import cats.implicits._
+import gem.Observation
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.SystemOverrides.overrideLogMessage
+import seqexec.server.keywords.{GdsClient, KeywordBag}
+import squants.time.Time
+
+class GhostControllerDisabled[F[_]: Logger: Applicative] extends GhostController[F] {
+  private val name = "GHOST"
+
+  override def gdsClient: GdsClient[F] = new GdsClient[F] {
+    override def setKeywords(id: ImageFileId, ks: KeywordBag): F[Unit] = overrideLogMessage(name, "setKeywords")
+
+    override def openObservation(obsId: Observation.Id, id: ImageFileId, ks: KeywordBag): F[Unit] =
+      overrideLogMessage(name, "openObservation")
+
+    override def closeObservation(id: ImageFileId): F[Unit] = overrideLogMessage(name, "closeObservation")
+  }
+
+  override def applyConfig(config: GhostConfig): F[Unit] = overrideLogMessage(name, "applyConfig")
+
+  override def observe(fileId: ImageFileId, expTime: Time): F[ImageFileId] = overrideLogMessage(name, s"observe $fileId").as(fileId)
+
+  override def endObserve: F[Unit] = overrideLogMessage(name, "endObserve")
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/ghost/GhostControllerDisabled.scala
@@ -2,7 +2,7 @@ package seqexec.server.ghost
 
 import cats.Applicative
 import cats.implicits._
-import gem.Observation
+import seqexec.model.Observation
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.SystemOverrides.overrideLogMessage

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -23,11 +23,10 @@ import edu.gemini.spModel.guide.StandardGuideOptions
 import edu.gemini.spModel.obscomp.InstConstants.EXPOSURE_TIME_PROP
 import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+import gsp.math.Angle
+import gsp.math.Offset
+import gsp.math.syntax.string._
 import io.chrisdavenport.log4cats.Logger
-import lucuma.core.enum.LightSinkName
-import lucuma.core.math.Angle
-import lucuma.core.math.Offset
-import lucuma.core.syntax.string._
 import seqexec.model.GmosParameters._
 import seqexec.model.`enum`.Instrument
 import seqexec.model.dhs.ImageFileId
@@ -57,8 +56,6 @@ abstract class Gmos[F[_]: Concurrent: Timer: Logger, T <: GmosController.SiteDep
 (configTypes: GmosController.Config[T]) extends DhsInstrument[F] with InstrumentSystem[F] {
   import Gmos._
   import InstrumentSystem._
-
-  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gmos
 
   override val contributorName: String = "gmosdc"
 

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -23,9 +23,9 @@ import edu.gemini.spModel.guide.StandardGuideOptions
 import edu.gemini.spModel.obscomp.InstConstants.EXPOSURE_TIME_PROP
 import edu.gemini.spModel.obscomp.InstConstants._
 import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
-import gsp.math.Angle
-import gsp.math.Offset
-import gsp.math.syntax.string._
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.syntax.string._
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.GmosParameters._
 import seqexec.model.`enum`.Instrument

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.gmos
 
 import cats.Applicative

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosControllerDisabled.scala
@@ -1,0 +1,40 @@
+package seqexec.server.gmos
+
+import cats.Applicative
+import cats.implicits._
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.`enum`.ObserveCommandResult
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.SystemOverrides.overrideLogMessage
+import seqexec.server.{InstrumentSystem, Progress}
+import seqexec.server.gmos.GmosController.SiteDependentTypes
+import squants.Time
+
+class GmosControllerDisabled[F[_]: Logger: Applicative, T <: SiteDependentTypes](name: String) extends GmosController[F, T] {
+  override def applyConfig(config: GmosController.GmosConfig[T]): F[Unit] = overrideLogMessage(name, "applyConfig")
+
+  override def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult] =
+    overrideLogMessage(name, s"observe $fileId").as(ObserveCommandResult.Success)
+
+  override def endObserve: F[Unit] = overrideLogMessage(name, "endObserve")
+
+  override def stopObserve: F[Unit] = overrideLogMessage(name, "stopObserve")
+
+  override def abortObserve: F[Unit] = overrideLogMessage(name, "abortObserve")
+
+  override def pauseObserve: F[Unit] = overrideLogMessage(name, "pauseObserve")
+
+  override def resumePaused(expTime: Time): F[ObserveCommandResult] =
+    overrideLogMessage(name, "resumePaused").as(ObserveCommandResult.Success)
+
+  override def stopPaused: F[ObserveCommandResult] =
+    overrideLogMessage(name, "stopPaused").as(ObserveCommandResult.Stopped)
+
+  override def abortPaused: F[ObserveCommandResult] =
+    overrideLogMessage(name, "abortPaused").as(ObserveCommandResult.Aborted)
+
+  override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime): Stream[F, Progress] = Stream.empty
+
+  override def nsCount: F[Int] = 0.pure[F]
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -9,21 +9,20 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
 
 object GmosHeader {
   def header[F[_]: Sync: Logger](
-    inst:              InstrumentSystem[F],
-    gmosObsReader:     GmosObsKeywordsReader[F],
-    gmosReader:        GmosKeywordReader[F],
-    tcsKeywordsReader: TcsKeywordsReader[F]
+                                  kwClient:          KeywordsClient[F],
+                                  gmosObsReader:     GmosObsKeywordsReader[F],
+                                  gmosReader:        GmosKeywordReader[F],
+                                  tcsKeywordsReader: TcsKeywordsReader[F]
   ): Header[F] =
     new Header[F] {
       override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
         nsBeforeKeywords.flatMap(nsKs =>
-          sendKeywords(id, inst, List(
+          sendKeywords(id, kwClient, List(
             buildInt32(tcsKeywordsReader.gmosInstPort, KeywordName.INPORT),
             buildString(gmosReader.ccName, KeywordName.GMOSCC),
             buildString(tcsKeywordsReader.ut, KeywordName.TIME_OBS),
@@ -94,7 +93,7 @@ object GmosHeader {
       ): F[Unit] =
         sendKeywords(
           id,
-          inst,
+          kwClient,
           List(
             buildInt32(gmosReader.maskId, KeywordName.MASKID),
             buildString(readMaskName, KeywordName.MASKNAME),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosInstrumentActions.scala
@@ -17,6 +17,7 @@ import seqexec.model.enum.Guiding
 import seqexec.model.enum.NodAndShuffleStage._
 import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.InstrumentActions._
+import seqexec.server.InstrumentSystem.ElapsedTime
 import seqexec.server.ObserveActions._
 import seqexec.server._
 import seqexec.server.gmos.GmosController.Config._
@@ -56,7 +57,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Timer: Logger, A <: GmosController
       case ObserveCommandResult.Stopped =>
         okTail(fileId, stopped = true, env)
       case ObserveCommandResult.Aborted =>
-        abortTail(env.systems, env.obsId, fileId)
+        abortTail(env.odb, env.obsId, fileId)
       case ObserveCommandResult.Paused =>
         env.inst
           .calcObserveTime(env.config)
@@ -66,6 +67,7 @@ class GmosInstrumentActions[F[_]: Concurrent: Timer: Logger, A <: GmosController
                 .Paused(
                   ObserveContext(
                     (_: Time) => resumeObserve(fileId, env, nsCfg),
+                    (_: ElapsedTime) => observationProgressStream(env),
                     stopPausedObserve(fileId, env, nsCfg),
                     abortPausedObserve(fileId, env, nsCfg),
                     e

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -12,7 +12,7 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.FPU_PROP_NAME
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.STAGE_MODE_PROP
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
-import gem.`enum`.LightSinkName
+import lucuma.core.enum.LightSinkName
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.{CleanConfig, ConfigUtilOps, InstrumentSpecifics, SeqexecFailure, StepType}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -14,9 +14,8 @@ import edu.gemini.spModel.gemini.gmos.InstGmosCommon.STAGE_MODE_PROP
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
-import seqexec.server.CleanConfig
+import seqexec.server.{CleanConfig, ConfigUtilOps, InstrumentSpecifics, SeqexecFailure, StepType}
 import seqexec.server.CleanConfig.extractItem
-import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.NorthTypes
@@ -70,4 +69,12 @@ object GmosNorth {
     dhsClient: DhsClient[F],
     nsCmdR: Ref[F, Option[NSObserveCommand]]
   ): GmosNorth[F] = new GmosNorth[F](c, dhsClient, nsCmdR)
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.GmosN
+
+    override def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
+      Gmos.calcStepType(instrument, config, isNightSeq)
+  }
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -12,6 +12,7 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.FPU_PROP_NAME
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.STAGE_MODE_PROP
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth._
+import gem.`enum`.LightSinkName
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.{CleanConfig, ConfigUtilOps, InstrumentSpecifics, SeqexecFailure, StepType}
@@ -57,8 +58,6 @@ final case class GmosNorth[F[_]: Concurrent: Timer: Logger] private (
   override val resource: Instrument = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"
 
-  // TODO Use different value if using electronic offsets
-  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 }
 
 object GmosNorth {
@@ -75,6 +74,12 @@ object GmosNorth {
 
     override def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
       Gmos.calcStepType(instrument, config, isNightSeq)
+
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gmos
+
+    // TODO Use different value if using electronic offsets
+    override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -12,7 +12,7 @@ import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.FPU_PROP_NAME
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.STAGE_MODE_PROP
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
-import gem.`enum`.LightSinkName
+import lucuma.core.enum.LightSinkName
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.{CleanConfig, ConfigUtilOps, InstrumentSpecifics, SeqexecFailure, StepType}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -14,9 +14,8 @@ import edu.gemini.spModel.gemini.gmos.InstGmosCommon.STAGE_MODE_PROP
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
-import seqexec.server.CleanConfig
+import seqexec.server.{CleanConfig, ConfigUtilOps, InstrumentSpecifics, SeqexecFailure, StepType}
 import seqexec.server.CleanConfig.extractItem
-import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps._
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.SouthTypes
@@ -71,4 +70,12 @@ object GmosSouth {
     dhsClient: DhsClient[F],
     nsCmdR: Ref[F, Option[NSObserveCommand]]
   ): GmosSouth[F] = new GmosSouth[F](c, dhsClient, nsCmdR)
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.GmosS
+
+    override def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
+      Gmos.calcStepType(instrument, config, isNightSeq)
+  }
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -12,6 +12,7 @@ import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.FPU_PROP_NAME
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon.STAGE_MODE_PROP
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
+import gem.`enum`.LightSinkName
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.enum.Instrument
 import seqexec.server.{CleanConfig, ConfigUtilOps, InstrumentSpecifics, SeqexecFailure, StepType}
@@ -57,9 +58,6 @@ final case class GmosSouth[F[_]: Concurrent: Timer: Logger] private (
 )(southConfigTypes) {
   override val resource: Instrument = Instrument.GmosS
   override val dhsInstrumentName: String = "GMOS-S"
-
-  // TODO Use different value if using electronic offsets
-  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 }
 
 object GmosSouth {
@@ -76,6 +74,12 @@ object GmosSouth {
 
     override def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
       Gmos.calcStepType(instrument, config, isNightSeq)
+
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gmos
+
+    // TODO Use different value if using electronic offsets
+    override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -242,4 +242,8 @@ object Gnirs {
         .getOrElse(ContentError(s"Invalid value for focus ($v)").asLeft)
     }
 
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.Gnirs
+  }
+
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -41,7 +41,6 @@ import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
 final case class Gnirs[F[_]: Logger: Concurrent: Timer](controller: GnirsController[F], dhsClient: DhsClient[F]) extends DhsInstrument[F] with InstrumentSystem[F] {
-  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gnirs
   override val contributorName: String = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"
 
@@ -244,6 +243,7 @@ object Gnirs {
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.Gnirs
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gnirs
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerDisabled.scala
@@ -1,0 +1,31 @@
+package seqexec.server.gnirs
+
+import cats.Applicative
+import cats.implicits._
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.`enum`.ObserveCommandResult
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.Progress
+import seqexec.server.SystemOverrides.overrideLogMessage
+import squants.Time
+
+class GnirsControllerDisabled[F[_]: Logger: Applicative] extends GnirsController[F] {
+  private val name = "GNIRS"
+
+  override def applyConfig(config: GnirsController.GnirsConfig): F[Unit] = overrideLogMessage(name, "applyConfig")
+
+  override def observe(fileId: ImageFileId, expTime: Time): F[ObserveCommandResult] =
+    overrideLogMessage(name, s"observe $fileId").as(ObserveCommandResult.Success)
+
+  override def endObserve: F[Unit] = overrideLogMessage(name, "endObserve")
+
+  override def stopObserve: F[Unit] = overrideLogMessage(name, "stopObserve")
+
+  override def abortObserve: F[Unit] = overrideLogMessage(name, "abortObserve")
+
+  override def observeProgress(total: Time): Stream[F, Progress] = Stream.empty
+
+  override def calcTotalExposureTime(cfg: GnirsController.DCConfig): F[Time] =
+    GnirsController.calcTotalExposureTime[F](cfg)
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.gnirs
 
 import cats.Applicative

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gnirs/GnirsHeader.scala
@@ -8,14 +8,13 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
 
 object GnirsHeader {
-  def header[F[_]: Sync: Logger](inst: InstrumentSystem[F], gnirsReader: GnirsKeywordReader[F], tcsReader: TcsKeywordsReader[F]): Header[F] = new Header[F] {
+  def header[F[_]: Sync: Logger](kwClient: KeywordsClient[F], gnirsReader: GnirsKeywordReader[F], tcsReader: TcsKeywordsReader[F]): Header[F] = new Header[F] {
     override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
-      sendKeywords(id, inst, List(
+      sendKeywords(id, kwClient, List(
         buildInt32(tcsReader.gnirsInstPort, KeywordName.INPORT),
         buildString(gnirsReader.arrayId, KeywordName.ARRAYID),
         buildString(gnirsReader.arrayType, KeywordName.ARRAYTYP),
@@ -47,7 +46,7 @@ object GnirsHeader {
       ) )
 
     override def sendAfter(id: ImageFileId): F[Unit] =
-      sendKeywords(id, inst, List(
+      sendKeywords(id, kwClient, List(
         buildString(tcsReader.ut, KeywordName.UTEND),
         buildDouble(gnirsReader.obsEpoch, KeywordName.OBSEPOCH)
       ) )

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -56,13 +56,6 @@ final case class Gpi[F[_]: Timer: Logger: Concurrent](controller: GpiController[
 
   override val contributorName: String = "gpi"
 
-  override def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
-    if (Gpi.isAlignAndCalib(config)) {
-      StepType.AlignAndCalib.asRight
-    } else {
-      SequenceConfiguration.calcStepType(config, isNightSeq)
-    }
-
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
     InstrumentSystem.Uncontrollable
 
@@ -224,5 +217,16 @@ object Gpi {
     ApplicativeError[F, Throwable]
       .catchNonFatal(isAlignAndCalib(config))
       .ifM(alignAndCalibConfig[F], regularSequenceConfig[F](config))
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.Gpi
+
+    override def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
+      if (Gpi.isAlignAndCalib(config)) {
+        StepType.AlignAndCalib.asRight
+      } else {
+        SequenceConfiguration.calcStepType(config, isNightSeq)
+      }
+  }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -52,8 +52,6 @@ final case class Gpi[F[_]: Timer: Logger: Concurrent](controller: GpiController[
 
   override val resource: Instrument = Instrument.Gpi
 
-  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gpi
-
   override val contributorName: String = "gpi"
 
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
@@ -227,6 +225,9 @@ object Gpi {
       } else {
         SequenceConfiguration.calcStepType(config, isNightSeq)
       }
+
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gpi
+
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.gpi
 
 import cats.Applicative

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiControllerDisabled.scala
@@ -2,7 +2,7 @@ package seqexec.server.gpi
 
 import cats.Applicative
 import cats.implicits._
-import gem.Observation
+import seqexec.model.Observation
 import giapi.client.GiapiStatusDb
 import io.chrisdavenport.log4cats.Logger
 import seqexec.model.dhs.ImageFileId

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gpi/GpiControllerDisabled.scala
@@ -1,0 +1,33 @@
+package seqexec.server.gpi
+
+import cats.Applicative
+import cats.implicits._
+import gem.Observation
+import giapi.client.GiapiStatusDb
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.SystemOverrides.overrideLogMessage
+import seqexec.server.keywords.{GdsClient, KeywordBag}
+import squants.time.Time
+
+class GpiControllerDisabled[F[_]: Logger: Applicative](override val statusDb: GiapiStatusDb[F]) extends GpiController[F] {
+  private val name = "GPI"
+
+  override def gdsClient: GdsClient[F] = new GdsClient[F] {
+    override def setKeywords(id: ImageFileId, ks: KeywordBag): F[Unit] = overrideLogMessage(name, "setKeywords")
+
+    override def openObservation(obsId: Observation.Id, id: ImageFileId, ks: KeywordBag): F[Unit] =
+      overrideLogMessage(name, "openObservation")
+
+    override def closeObservation(id: ImageFileId): F[Unit] = overrideLogMessage(name, "closeObservation")
+  }
+
+  override def alignAndCalib: F[Unit] = overrideLogMessage(name, "alignAndCalib")
+
+  override def applyConfig(config: GpiConfig): F[Unit] = overrideLogMessage(name, "applyConfig")
+
+  override def observe(fileId: ImageFileId, expTime: Time): F[ImageFileId] =
+    overrideLogMessage(name, s"observe $fileId").as(fileId)
+
+  override def endObserve: F[Unit] = overrideLogMessage(name, "endObserve")
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -20,17 +20,11 @@ import lucuma.core.enum.LightSinkName
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.ObserveCommandResult
-import seqexec.server.CleanConfig
+import seqexec.server.{CleanConfig, ConfigResult, ConfigUtilOps, InstrumentActions, InstrumentSpecifics, InstrumentSystem, Progress, SeqexecFailure}
 import seqexec.server.CleanConfig.extractItem
-import seqexec.server.ConfigResult
-import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps.ExtractFailure
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.InstrumentActions
-import seqexec.server.InstrumentSystem
 import seqexec.server.InstrumentSystem._
-import seqexec.server.Progress
-import seqexec.server.SeqexecFailure
 import seqexec.server.gsaoi.GsaoiController._
 import seqexec.server.keywords.DhsClient
 import seqexec.server.keywords.DhsInstrument
@@ -176,5 +170,9 @@ object Gsaoi {
       cc <- readCCConfig(config).adaptExtractFailure
       dc <- readDCConfig(config).adaptExtractFailure
     } yield GsaoiConfig(cc, dc)
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.Gsaoi
+  }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -44,8 +44,6 @@ final case class Gsaoi[F[_]: Logger: Concurrent: Timer](
 
   import Gsaoi._
 
-  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gsaoi
-
   override val contributorName: String = "GSAOI"
 
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
@@ -78,8 +76,6 @@ final case class Gsaoi[F[_]: Logger: Concurrent: Timer](
     elapsed: InstrumentSystem.ElapsedTime
   ): fs2.Stream[F, Progress] =
     controller.observeProgress(total)
-
-  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 
   override val dhsInstrumentName: String = "GSAOI"
 
@@ -173,6 +169,11 @@ object Gsaoi {
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.Gsaoi
+
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Gsaoi
+
+    override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerDisabled.scala
@@ -1,0 +1,28 @@
+package seqexec.server.gsaoi
+
+import cats.Functor
+import cats.implicits._
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.`enum`.ObserveCommandResult
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.Progress
+import seqexec.server.SystemOverrides.overrideLogMessage
+import squants.Time
+
+class GsaoiControllerDisabled[F[_]: Logger: Functor] extends GsaoiController[F] {
+  private val name = "GSAOI"
+
+  override def applyConfig(config: GsaoiController.GsaoiConfig): F[Unit] = overrideLogMessage(name, "")
+
+  override def observe(fileId: ImageFileId, cfg: GsaoiController.DCConfig): F[ObserveCommandResult] =
+    overrideLogMessage(name, s"observe $fileId").as(ObserveCommandResult.Success)
+
+  override def endObserve: F[Unit] = overrideLogMessage(name, "endObserve")
+
+  override def stopObserve: F[Unit] = overrideLogMessage(name, "stopObserve")
+
+  override def abortObserve: F[Unit] = overrideLogMessage(name, "abortObserve")
+
+  override def observeProgress(total: Time): Stream[F, Progress] = Stream.empty
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.gsaoi
 
 import cats.Functor

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gsaoi/GsaoiHeader.scala
@@ -8,21 +8,20 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
 
 object GsaoiHeader extends GsaoiLUT {
 
   def header[F[_]: Sync: Logger](
-    inst:              InstrumentSystem[F],
-    tcsKeywordsReader: TcsKeywordsReader[F],
-    instReader:        GsaoiKeywordReader[F]
+                                  kwClient:          KeywordsClient[F],
+                                  tcsKeywordsReader: TcsKeywordsReader[F],
+                                  instReader:        GsaoiKeywordReader[F]
   ): Header[F] = new Header[F] {
     override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
       sendKeywords(
         id,
-        inst,
+        kwClient,
         List(
           buildInt32(tcsKeywordsReader.gsaoiInstPort, KeywordName.INPORT),
           buildString(instReader.upperFilter, KeywordName.FILTER1),
@@ -63,7 +62,7 @@ object GsaoiHeader extends GsaoiLUT {
     override def sendAfter(id: ImageFileId): F[Unit] =
       sendKeywords(
         id,
-        inst,
+        kwClient,
         List(
           buildDouble(instReader.obsElapsedTime, KeywordName.ELAPSED),
           buildDouble(instReader.readInterval, KeywordName.READDLAY)

--- a/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/gws/GwsHeader.scala
@@ -10,15 +10,14 @@ import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
 import seqexec.server.EpicsHealth
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 
 object GwsHeader {
-  def header[F[_]: MonadError[?[_], Throwable]: Logger](inst: InstrumentSystem[F], gwsReader: GwsKeywordReader[F]): Header[F] = new Header[F] {
+  def header[F[_]: MonadError[?[_], Throwable]: Logger](kwClient: KeywordsClient[F], gwsReader: GwsKeywordReader[F]): Header[F] = new Header[F] {
     override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
       gwsReader.health.map(_ === EpicsHealth.Good)
         .handleError(_ => false) // error check the health read
-        .ifM(sendKeywords[F](id, inst, List(
+        .ifM(sendKeywords[F](id, kwClient, List(
           buildDouble(gwsReader.humidity, KeywordName.HUMIDITY),
           buildDouble(gwsReader.temperature.map(_.toCelsiusScale), KeywordName.TAMBIENT),
           buildDouble(gwsReader.temperature.map(_.toFahrenheitScale), KeywordName.TAMBIEN2),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientDisabled.scala
@@ -1,0 +1,24 @@
+package seqexec.server.keywords
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import cats.effect.Sync
+import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.dhs.{ImageFileId, toImageFileId}
+import seqexec.server.SystemOverrides.overrideLogMessage
+
+class DhsClientDisabled[F[_]: Sync: Logger] extends DhsClient[F] {
+
+  val format: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+
+  override def createImage(p: DhsClient.ImageParameters): F[ImageFileId] = for {
+    _ <- overrideLogMessage("DHS", "setKeywords")
+    date <- Sync[F].delay(LocalDate.now)
+    time <- Sync[F].delay(System.currentTimeMillis % 1000)
+  } yield toImageFileId(f"S${date.format(format)}S${time}%04d")
+
+  override def setKeywords(id: ImageFileId, keywords: KeywordBag, finalFlag: Boolean): F[Unit] =
+    overrideLogMessage("DHS", "setKeywords")
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/DhsClientDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.keywords
 
 import java.time.LocalDate

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/GdsClient.scala
@@ -25,135 +25,149 @@ import seqexec.server.SeqexecFailure
 /**
   * Gemini Data service client
   */
-final case class GdsClient[F[_]: Concurrent](base: Client[F], gdsUri: Uri)(implicit timer: Timer[F])
-    extends Http4sClientDsl[F] {
-
-  private val client = {
-    val max = 2
-    var attemptsCounter = 1
-    val policy = RetryPolicy[F] { attempts: Int =>
-      if (attempts >= max) None
-      else {
-        attemptsCounter = attemptsCounter + 1
-        Some(10.milliseconds)
-      }
-    }
-    Retry(policy)(base)
-  }
-
-  // Build an xml rpc request to store keywords
-  private def storeKeywords(id: ImageFileId, ks: KeywordBag): Elem =
-    <methodCall>
-      <methodName>HeaderReceiver.storeKeywords</methodName>
-      <params>
-        <param>
-          <value>
-            <string>{id}</string>
-          </value>
-        </param>
-        {keywordsParam(ks)}
-      </params>
-    </methodCall>
-
+trait GdsClient[F[_]] extends Http4sClientDsl[F] {
   /**
     * Set the keywords for an image
     */
-  def setKeywords(id: ImageFileId, ks: KeywordBag): F[Unit] = {
-    // Build the request
-    val xmlRpc      = storeKeywords(id, ks)
-    val postRequest = POST(xmlRpc, gdsUri)
-
-    // Do the request
-    client
-      .expect[Elem](postRequest)(scalaxml.xml)
-      .map(GdsClient.parseError)
-      .ensureOr(toSeqexecFailure)(_.isRight)
-      .void
-  }
-
-  // Build an xml rpc request to open an observation
-  private def openObservationRPC(obsId: Observation.Id,
-                                 id: ImageFileId,
-                                 ks: KeywordBag): Elem =
-    <methodCall>
-      <methodName>HeaderReceiver.openObservation</methodName>
-      <params>
-        <param>
-          <value>
-            <string>{obsId.format}</string>
-          </value>
-        </param>
-        <param>
-          <value>
-            <string>{id}</string>
-          </value>
-        </param>
-        {keywordsParam(ks)}
-      </params>
-    </methodCall>
+  def setKeywords(id: ImageFileId, ks: KeywordBag): F[Unit]
 
   def openObservation(obsId: Observation.Id,
                       id: ImageFileId,
-                      ks: KeywordBag): F[Unit] = {
-    // Build the request
-    val xmlRpc      = openObservationRPC(obsId, id, ks)
-    val postRequest = POST(xmlRpc, gdsUri)
+                      ks: KeywordBag): F[Unit]
 
-    // Do the request
-    client
-      .expect[Elem](postRequest)(scalaxml.xml)
-      .map(GdsClient.parseError)
-      .ensureOr(toSeqexecFailure)(_.isRight)
-      .void
-  }
-
-  // Build an xml rpc request to close an observation
-  private def closeObservationRPC(id: ImageFileId): Elem =
-    <methodCall>
-      <methodName>HeaderReceiver.closeObservation</methodName>
-      <params>
-        <param>
-          <value>
-            <string>{id}</string>
-          </value>
-        </param>
-      </params>
-    </methodCall>
-
-  def closeObservation(id: ImageFileId): F[Unit] = {
-    // Build the request
-    val xmlRpc      = closeObservationRPC(id)
-    val postRequest = POST(xmlRpc, gdsUri)
-
-    // Do the request
-    client
-      .expect[Elem](postRequest)(scalaxml.xml)
-      .map(GdsClient.parseError)
-      .ensureOr(toSeqexecFailure)(_.isRight)
-      .void
-  }
-
-  private def keywordsParam(ks: KeywordBag): Elem =
-    <param>
-      <value>
-        <array>
-          <data>
-            {
-              ks.keywords.map { k =>
-                <value><string>{s"${k.name},${KeywordType.gdsKeywordType(k.keywordType)},${k.value}"}</string></value>
-              }
-            }
-          </data>
-        </array>
-      </value>
-    </param>
-
-  def toSeqexecFailure(v: Either[String, Elem]): SeqexecFailure =
-    SeqexecFailure.GdsXmlError(v.left.getOrElse(""), gdsUri)
-
+  def closeObservation(id: ImageFileId): F[Unit]
 }
 
 object GdsClient {
+
+  def apply[F[_]: Concurrent](base: Client[F], gdsUri: Uri)(implicit timer: Timer[F]): GdsClient[F] = new GdsClient[F] {
+
+    private val client = {
+      val max = 2
+      var attemptsCounter = 1
+      val policy = RetryPolicy[F] { attempts: Int =>
+        if (attempts >= max) None
+        else {
+          attemptsCounter = attemptsCounter + 1
+          Some(10.milliseconds)
+        }
+      }
+      Retry(policy)(base)
+    }
+
+    // Build an xml rpc request to store keywords
+    private def storeKeywords(id: ImageFileId, ks: KeywordBag): Elem =
+      <methodCall>
+        <methodName>HeaderReceiver.storeKeywords</methodName>
+        <params>
+          <param>
+            <value>
+              <string>{id}</string>
+            </value>
+          </param>
+          {keywordsParam(ks)}
+        </params>
+      </methodCall>
+
+    /**
+      * Set the keywords for an image
+      */
+    override def setKeywords(id: ImageFileId, ks: KeywordBag): F[Unit] = {
+      // Build the request
+      val xmlRpc      = storeKeywords(id, ks)
+      val postRequest = POST(xmlRpc, gdsUri)
+
+      // Do the request
+      client
+        .expect[Elem](postRequest)(scalaxml.xml)
+        .map(GdsClient.parseError)
+        .ensureOr(toSeqexecFailure)(_.isRight)
+        .void
+    }
+
+    // Build an xml rpc request to open an observation
+    private def openObservationRPC(obsId: Observation.Id,
+                                   id: ImageFileId,
+                                   ks: KeywordBag): Elem =
+      <methodCall>
+        <methodName>HeaderReceiver.openObservation</methodName>
+        <params>
+          <param>
+            <value>
+              <string>{obsId.format}</string>
+            </value>
+          </param>
+          <param>
+            <value>
+              <string>{id}</string>
+            </value>
+          </param>
+          {keywordsParam(ks)}
+        </params>
+      </methodCall>
+
+    override def openObservation(obsId: Observation.Id,
+                        id: ImageFileId,
+                        ks: KeywordBag): F[Unit] = {
+      // Build the request
+      val xmlRpc      = openObservationRPC(obsId, id, ks)
+      val postRequest = POST(xmlRpc, gdsUri)
+
+      // Do the request
+      client
+        .expect[Elem](postRequest)(scalaxml.xml)
+        .map(GdsClient.parseError)
+        .ensureOr(toSeqexecFailure)(_.isRight)
+        .void
+    }
+
+    // Build an xml rpc request to close an observation
+    private def closeObservationRPC(id: ImageFileId): Elem =
+      <methodCall>
+        <methodName>HeaderReceiver.closeObservation</methodName>
+        <params>
+          <param>
+            <value>
+              <string>{id}</string>
+            </value>
+          </param>
+        </params>
+      </methodCall>
+
+    override def closeObservation(id: ImageFileId): F[Unit] = {
+      // Build the request
+      val xmlRpc      = closeObservationRPC(id)
+      val postRequest = POST(xmlRpc, gdsUri)
+
+      // Do the request
+      client
+        .expect[Elem](postRequest)(scalaxml.xml)
+        .map(GdsClient.parseError)
+        .ensureOr(toSeqexecFailure)(_.isRight)
+        .void
+    }
+
+    private def keywordsParam(ks: KeywordBag): Elem =
+      <param>
+        <value>
+          <array>
+            <data>
+              {
+                ks.keywords.map { k =>
+                  <value><string>{s"${k.name},${KeywordType.gdsKeywordType(k.keywordType)},${k.value}"}</string></value>
+                }
+              }
+            </data>
+          </array>
+        </value>
+      </param>
+
+    def toSeqexecFailure(v: Either[String, Elem]): SeqexecFailure =
+      SeqexecFailure.GdsXmlError(v.left.getOrElse(""), gdsUri)
+
+  }
+
+
 
   def parseError(e: Elem): Either[String, Elem] = {
     val v = for {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -290,15 +290,14 @@ package object keywords {
 
   def sendKeywords[F[_]: MonadError[*[_], Throwable]: Logger](
       id: ImageFileId,
-      inst: InstrumentSystem[F],
+      keywClient: KeywordsClient[F],
       b: List[KeywordBag => F[KeywordBag]]): F[Unit] =
-    inst
-      .keywordsClient
+    keywClient
       .keywordsBundler
       .bundleKeywords(b)
       .redeemWith(e => Logger[F].error(e.getMessage) *> KeywordBag.empty.pure[F], _.pure[F])
       .flatMap { bag =>
-        inst.keywordsClient.setKeywords(id, bag, finalFlag = false)
+        keywClient.setKeywords(id, bag, finalFlag = false)
       }
 
   def dummyHeader[F[_]: Applicative]: Header[F] = new Header[F] {

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -49,8 +49,6 @@ final case class Nifs[F[_]: Logger: Concurrent: Timer](
 
   import Nifs._
 
-  override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Nifs
-
   override val contributorName: String = "NIFS"
 
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
@@ -78,8 +76,6 @@ final case class Nifs[F[_]: Logger: Concurrent: Timer](
     elapsed: InstrumentSystem.ElapsedTime
   ): fs2.Stream[F, Progress] =
     controller.observeProgress(total)
-
-  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 
   override val dhsInstrumentName: String = "NIFS"
 
@@ -231,6 +227,11 @@ object Nifs {
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.Nifs
+
+    override def sfName(config: CleanConfig): LightSinkName = LightSinkName.Nifs
+
+    override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -23,18 +23,13 @@ import lucuma.core.enum.LightSinkName
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.ObserveCommandResult
-import seqexec.server.CleanConfig
+import seqexec.server.{CleanConfig, ConfigResult, InstrumentActions, InstrumentSpecifics, InstrumentSystem, Progress, SeqexecFailure}
 import seqexec.server.CleanConfig.extractItem
-import seqexec.server.ConfigResult
 import seqexec.server.ConfigUtilOps.ExtractFailure
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.InstrumentActions
-import seqexec.server.InstrumentSystem
 import seqexec.server.InstrumentSystem.AbortObserveCmd
 import seqexec.server.InstrumentSystem.StopObserveCmd
 import seqexec.server.InstrumentSystem.UnpausableControl
-import seqexec.server.Progress
-import seqexec.server.SeqexecFailure
 import seqexec.server.keywords.DhsClient
 import seqexec.server.keywords.DhsInstrument
 import seqexec.server.keywords.KeywordsClient
@@ -233,5 +228,9 @@ object Nifs {
       cc <- getCCConfig(config).adaptExtractFailure
       dc <- getDCConfig(config).adaptExtractFailure
     } yield NifsConfig(cc, dc)
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.Nifs
+  }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.nifs
 
 import cats.Applicative

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsControllerDisabled.scala
@@ -1,0 +1,30 @@
+package seqexec.server.nifs
+
+import cats.Applicative
+import cats.implicits._
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.`enum`.ObserveCommandResult
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.Progress
+import seqexec.server.SystemOverrides.overrideLogMessage
+import squants.Time
+
+class NifsControllerDisabled[F[_]: Logger: Applicative] extends NifsController[F] {
+  private val name = "NIFS"
+
+  override def applyConfig(config: NifsController.NifsConfig): F[Unit] = overrideLogMessage(name, "applyConfig")
+
+  override def observe(fileId: ImageFileId, cfg: NifsController.DCConfig): F[ObserveCommandResult] =
+    overrideLogMessage(name, "").as(ObserveCommandResult.Success)
+
+  override def endObserve: F[Unit] = overrideLogMessage(name, "endObserve")
+
+  override def stopObserve: F[Unit] = overrideLogMessage(name, "stopObserve")
+
+  override def abortObserve: F[Unit] = overrideLogMessage(name, "abortObserve")
+
+  override def observeProgress(total: Time): Stream[F, Progress] = Stream.empty
+
+  override def calcTotalExposureTime(cfg: NifsController.DCConfig): Time = NifsController.calcTotalExposureTime[F](cfg)
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/nifs/NifsHeader.scala
@@ -9,21 +9,20 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords._
 import seqexec.server.tcs.TcsKeywordsReader
 
 object NifsHeader {
 
   def header[F[_]: MonadError[?[_], Throwable]: Logger](
-    inst:              InstrumentSystem[F],
-    instReader:        NifsKeywordReader[F],
-    tcsKeywordsReader: TcsKeywordsReader[F]
+                                                         kwClient:          KeywordsClient[F],
+                                                         instReader:        NifsKeywordReader[F],
+                                                         tcsKeywordsReader: TcsKeywordsReader[F]
   ): Header[F] = new Header[F] {
     override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] = {
       sendKeywords(
         id,
-        inst,
+        kwClient,
         List(
           buildString(instReader.grating, KeywordName.GRATING),
           buildString(instReader.aperture, KeywordName.APERTURE),
@@ -50,7 +49,7 @@ object NifsHeader {
 
     override def sendAfter(id: ImageFileId): F[Unit] =
       sendKeywords(id,
-                   inst,
+                   kwClient,
                    List(
                      buildDouble(instReader.exposureTime, KeywordName.EXPTIME)
                    ))

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -47,13 +47,6 @@ final case class Niri[F[_]: Timer: Logger: Concurrent](controller: NiriControlle
 
   import Niri._
 
-  override def sfName(config: CleanConfig): LightSinkName = getCameraConfig(config).map{
-    case Camera.F6     => LightSinkName.Niri_f6
-    case Camera.F14    => LightSinkName.Niri_f14
-    case Camera.F32 |
-         Camera.F32_PV => LightSinkName.Niri_f32
-  }.getOrElse(LightSinkName.Niri_f6)
-
   override val contributorName: String = "mko-dc-data-niri"
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
     UnpausableControl(
@@ -75,8 +68,6 @@ final case class Niri[F[_]: Timer: Logger: Concurrent](controller: NiriControlle
 
   override def observeProgress(total: Time, elapsed: InstrumentSystem.ElapsedTime)
   : fs2.Stream[F, Progress] = controller.observeProgress(total)
-
-  override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
 
   override val dhsInstrumentName: String = "NIRI"
 
@@ -177,6 +168,16 @@ object Niri {
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.Niri
+
+    override def sfName(config: CleanConfig): LightSinkName = getCameraConfig(config).map{
+      case Camera.F6     => LightSinkName.Niri_f6
+      case Camera.F14    => LightSinkName.Niri_f14
+      case Camera.F32 |
+           Camera.F32_PV => LightSinkName.Niri_f32
+    }.getOrElse(LightSinkName.Niri_f6)
+
+    override val oiOffsetGuideThreshold: Option[Length] = (Arcseconds(0.01)/FOCAL_PLANE_SCALE).some
+
   }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -25,19 +25,13 @@ import lucuma.core.enum.LightSinkName
 import seqexec.model.dhs.ImageFileId
 import seqexec.model.enum.Instrument
 import seqexec.model.enum.ObserveCommandResult
-import seqexec.server.CleanConfig
+import seqexec.server.{CleanConfig, ConfigResult, ConfigUtilOps, InstrumentActions, InstrumentSpecifics, InstrumentSystem, Progress, SeqexecFailure}
 import seqexec.server.CleanConfig.extractItem
-import seqexec.server.ConfigResult
-import seqexec.server.ConfigUtilOps
 import seqexec.server.ConfigUtilOps.ExtractFailure
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.InstrumentActions
-import seqexec.server.InstrumentSystem
 import seqexec.server.InstrumentSystem.AbortObserveCmd
 import seqexec.server.InstrumentSystem.StopObserveCmd
 import seqexec.server.InstrumentSystem.UnpausableControl
-import seqexec.server.Progress
-import seqexec.server.SeqexecFailure
 import seqexec.server.keywords.DhsClient
 import seqexec.server.keywords.DhsInstrument
 import seqexec.server.keywords.KeywordsClient
@@ -180,5 +174,9 @@ object Niri {
     cc <- getCCConfig(config)
     dc <- getDCConfig(config)
   } yield NiriConfig(cc, dc)
+
+  object specifics extends InstrumentSpecifics {
+    override val instrument: Instrument = Instrument.Niri
+  }
 
 }

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerDisabled.scala
@@ -1,0 +1,35 @@
+package seqexec.server.niri
+
+import cats.Applicative
+import cats.implicits._
+import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.`enum`.ObserveCommandResult
+import seqexec.model.dhs.ImageFileId
+import seqexec.server.Progress
+import seqexec.server.SystemOverrides.overrideLogMessage
+import squants.Time
+import squants.time.TimeConversions._
+
+class NiriControllerDisabled[F[_]: Logger: Applicative] extends NiriController[F] {
+  private val name = "NIRI"
+
+  override def applyConfig(config: NiriController.NiriConfig): F[Unit] = overrideLogMessage(name, "applyConfig")
+
+  override def observe(fileId: ImageFileId, cfg: NiriController.DCConfig): F[ObserveCommandResult] =
+    overrideLogMessage(name, s"observe $fileId").as(ObserveCommandResult.Success)
+
+  override def endObserve: F[Unit] = overrideLogMessage(name, "endObserve")
+
+  override def stopObserve: F[Unit] = overrideLogMessage(name, "stopObserve")
+
+  override def abortObserve: F[Unit] = overrideLogMessage(name, "abortObserve")
+
+  override def observeProgress(total: Time): Stream[F, Progress] = Stream.empty
+
+  override def calcTotalExposureTime(cfg: NiriController.DCConfig): F[Time] = {
+    val MinIntTime = 0.5.seconds
+
+    (cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble
+  }.pure[F]
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.niri
 
 import cats.Applicative

--- a/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/niri/NiriHeader.scala
@@ -8,7 +8,6 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.core.enum.KeywordName
 import seqexec.model.Observation
 import seqexec.model.dhs.ImageFileId
-import seqexec.server.InstrumentSystem
 import seqexec.server.keywords.Header
 import seqexec.server.keywords._
 import seqexec.server.keywords.buildDouble
@@ -16,10 +15,10 @@ import seqexec.server.keywords.buildString
 import seqexec.server.tcs.TcsKeywordsReader
 
 object NiriHeader {
-  def header[F[_]: Sync: Logger](inst: InstrumentSystem[F], instReader: NiriKeywordReader[F],
-             tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] = new Header[F] {
+  def header[F[_]: Sync: Logger](kwClient: KeywordsClient[F], instReader: NiriKeywordReader[F],
+                                 tcsKeywordsReader: TcsKeywordsReader[F]): Header[F] = new Header[F] {
     override def sendBefore(obsId: Observation.Id, id: ImageFileId): F[Unit] =
-      sendKeywords(id, inst, List(
+      sendKeywords(id, kwClient, List(
         buildString(instReader.arrayId, KeywordName.ARRAYID),
         buildString(instReader.arrayType, KeywordName.ARRAYTYP),
         buildString(instReader.camera, KeywordName.CAMERA),
@@ -57,7 +56,7 @@ object NiriHeader {
       ))
 
     override def sendAfter(id: ImageFileId): F[Unit] =
-      sendKeywords(id, inst, List(
+      sendKeywords(id, kwClient, List(
         buildDouble(instReader.detectorTemperature, KeywordName.A_TDETABS),
         buildDouble(instReader.mountTemperature, KeywordName.A_TMOUNT),
         buildDouble(instReader.cl1VoltageDD, KeywordName.A_VDDCL1),

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerDisabled.scala
@@ -1,0 +1,22 @@
+package seqexec.server.tcs
+
+import cats.data.NonEmptySet
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.`enum`.NodAndShuffleStage
+import seqexec.server.SystemOverrides.overrideLogMessage
+import seqexec.server.altair.Altair
+import seqexec.server.tcs.TcsNorthController.TcsNorthConfig
+
+class TcsNorthControllerDisabled[F[_]: Logger] extends TcsNorthController[F] {
+  override def applyConfig(subsystems: NonEmptySet[TcsController.Subsystem], gaos: Option[Altair[F]], tc: TcsNorthConfig)
+  : F[Unit] =
+    overrideLogMessage("TCS", "applyConfig")
+
+  override def notifyObserveStart: F[Unit] = overrideLogMessage("TCS", "notifyObserveStart")
+
+  override def notifyObserveEnd: F[Unit] = overrideLogMessage("TCS", "notifyObserveEnd")
+
+  override def nod(subsystems: NonEmptySet[TcsController.Subsystem], tcsConfig: TcsNorthConfig)
+                  (stage: NodAndShuffleStage, offset: TcsController.InstrumentOffset, guided: Boolean)
+  : F[Unit] = overrideLogMessage("TCS", s"nod(${stage.symbol})")
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.tcs
 
 import cats.data.NonEmptySet

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouth.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouth.scala
@@ -18,12 +18,9 @@ import seqexec.model.enum.M1Source
 import seqexec.model.enum.NodAndShuffleStage
 import seqexec.model.enum.Resource
 import seqexec.model.enum.TipTiltSource
-import seqexec.server.CleanConfig
+import seqexec.server.{CleanConfig, ConfigResult, InstrumentGuide, SeqexecFailure}
 import seqexec.server.CleanConfig.extractItem
-import seqexec.server.ConfigResult
 import seqexec.server.ConfigUtilOps._
-import seqexec.server.InstrumentSystem
-import seqexec.server.SeqexecFailure
 import seqexec.server.gems.Gems
 import seqexec.server.gems.GemsController.GemsConfig
 import seqexec.server.tcs.TcsController.AGConfig
@@ -189,11 +186,11 @@ object TcsSouth {
     offsetA: Option[InstrumentOffset],
     wavelA: Option[Wavelength],
     lightPath: LightPath,
-    instrument: InstrumentSystem[F]
+    instrument: InstrumentGuide
   )
 
   def fromConfig[F[_]: Sync: Logger](controller: TcsSouthController[F], subsystems: NonEmptySet[Subsystem],
-                             gaos: Option[Gems[F]], instrument: InstrumentSystem[F], guideConfigDb: GuideConfigDb[F])(
+                                     gaos: Option[Gems[F]], instrument: InstrumentGuide, guideConfigDb: GuideConfigDb[F])(
     config: CleanConfig, lightPath: LightPath, observingWavelength: Option[Wavelength]
   ): TcsSouth[F] = {
 
@@ -212,7 +209,7 @@ object TcsSouth {
     val offsetq = config.extractTelescopeAs[String](Q_OFFSET_PROP).toOption.flatMap(_.parseDoubleOption)
       .map(Arcseconds(_):Angle).map(tag[OffsetQ](_))
 
-    val tcsSeqCfg = TcsSeqConfig(
+    val tcsSeqCfg = TcsSeqConfig[F](
       gwp1,
       gwp2,
       gwoi,

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerDisabled.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package seqexec.server.tcs
 
 import cats.data.NonEmptySet

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerDisabled.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerDisabled.scala
@@ -1,0 +1,22 @@
+package seqexec.server.tcs
+
+import cats.data.NonEmptySet
+import io.chrisdavenport.log4cats.Logger
+import seqexec.model.`enum`.NodAndShuffleStage
+import seqexec.server.SystemOverrides.overrideLogMessage
+import seqexec.server.gems.Gems
+import seqexec.server.tcs.TcsSouthController.TcsSouthConfig
+
+class TcsSouthControllerDisabled[F[_]: Logger] extends TcsSouthController[F] {
+  override def applyConfig(subsystems: NonEmptySet[TcsController.Subsystem], gaos: Option[Gems[F]], tc: TcsSouthConfig)
+  : F[Unit] =
+    overrideLogMessage("TCS", "applyConfig")
+
+  override def notifyObserveStart: F[Unit] = overrideLogMessage("TCS", "notifyObserveStart")
+
+  override def notifyObserveEnd: F[Unit] = overrideLogMessage("TCS", "notifyObserveEnd")
+
+  override def nod(subsystems: NonEmptySet[TcsController.Subsystem], tcsConfig: TcsSouthConfig)
+                  (stage: NodAndShuffleStage, offset: TcsController.InstrumentOffset, guided: Boolean)
+  : F[Unit] = overrideLogMessage("TCS", s"nod(${stage.symbol})")
+}

--- a/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/seqexec/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -217,7 +217,7 @@ object TcsSouthControllerEpicsAo {
       val becauseP1 = distanceSquared.exists(dd => Tcs.calcGuiderInUse(demand.gc, TipTiltSource.PWFS1, M1Source.PWFS1)
         && dd > pwfs1OffsetThreshold * pwfs1OffsetThreshold )
 
-      val beacauseOi = demand.inst.oiOffsetGuideThreshold.exists(t =>
+      val becauseOi = demand.inst.oiOffsetGuideThreshold.exists(t =>
         Tcs.calcGuiderInUse(demand.gc, TipTiltSource.OIWFS, M1Source.OIWFS) && distanceSquared.exists(_ > t*t ))
 
       val becauseAo = demand.gc.m1Guide match {
@@ -225,7 +225,7 @@ object TcsSouthControllerEpicsAo {
         case _                        => false
       }
 
-      beacauseOi || becauseP1 || becauseAo
+      becauseOi || becauseP1 || becauseAo
     }
 
     def calcAoPauseConditions(current: EpicsTcsAoConfig, baseAoConfig: GemsConfig, demand: TcsSouthAoConfig): PauseConditionSet =

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -10,7 +10,7 @@ import cats.data.NonEmptyList
 import fs2.Stream
 import seqexec.model.Observation
 import lucuma.core.enum.Site
-mport io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.noop.NoOpLogger
 
 import scala.concurrent.ExecutionContext

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -10,6 +10,7 @@ import cats.data.NonEmptyList
 import fs2.Stream
 import seqexec.model.Observation
 import lucuma.core.enum.Site
+mport io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.noop.NoOpLogger
 
 import scala.concurrent.ExecutionContext
@@ -23,7 +24,7 @@ import squants.time.Seconds
 import org.scalatest.flatspec.AnyFlatSpec
 
 class SeqTranslateSpec extends AnyFlatSpec {
-  private implicit def logger = NoOpLogger.impl[IO]
+  private implicit def logger: Logger[IO] = NoOpLogger.impl[IO]
 
   implicit val ioTimer: Timer[IO]        = IO.timer(ExecutionContext.global)
   implicit val csTimer: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
@@ -49,10 +50,8 @@ class SeqTranslateSpec extends AnyFlatSpec {
         Monoid.empty[DataId],
         config,
         Set(GmosS),
-        SequenceGen.StepActionsGen(List(),
-                                   Map(),
-                                   _ => List(observeActions(Action.ActionState.Idle))
-        )
+        _ => InstrumentSystem.Uncontrollable,
+        SequenceGen.StepActionsGen(Map.empty, (_, _) => List(observeActions(Action.ActionState.Idle)))
       )
     )
   )
@@ -77,20 +76,17 @@ class SeqTranslateSpec extends AnyFlatSpec {
     .sequenceStateIndex[IO](seqId)
     .modify(_.start(0).mark(0)(Result.Partial(FileIdAllocated(toImageFileId(fileId)))))(baseState)
   // Observe paused
-  private val s4: EngineState[IO] = EngineState
-    .sequenceStateIndex[IO](seqId)
-    .modify(
-      _.mark(0)(
-        Result.Paused(
-          ObserveContext[IO](
-            _ => Stream.emit(Result.OK(Observed(toImageFileId(fileId)))).covary[IO],
-            Stream.emit(Result.OK(Observed(toImageFileId(fileId)))).covary[IO],
-            Stream.eval(SeqexecFailure.Aborted(seqId).raiseError[IO, Result[IO]]),
-            Seconds(1)
-          )
-        )
+  private val s4: EngineState[IO] = EngineState.sequenceStateIndex[IO](seqId)
+    .modify(_.mark(0)(
+      Result.Paused(
+        ObserveContext[IO](
+          _ => Stream.emit(Result.OK(Observed(toImageFileId(fileId)))).covary[IO],
+          _ => Stream.empty,
+          Stream.emit(Result.OK(Observed(toImageFileId(fileId)))).covary[IO],
+          Stream.eval(SeqexecFailure.Aborted(seqId).raiseError[IO, Result[IO]]),
+          Seconds(1))
       )
-    )(baseState)
+    ))(baseState)
   // Observe failed
   private val s5: EngineState[IO] = EngineState
     .sequenceStateIndex[IO](seqId)

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -352,17 +352,11 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
               )
             ),
             resources = resources,
+            _ => InstrumentSystem.Uncontrollable,
             generator = SequenceGen.StepActionsGen(
-              pre = Nil,
-              configs = resources.map(r => r -> pendingAction[IO](r)).toMap,
-              post = _ => Nil
+              configs = resources.map(r => r -> {_:SystemOverrides => pendingAction[IO](r)}).toMap,
+              post = (_, _) => Nil
             )
-          ),
-          resources = resources,
-          _ => InstrumentSystem.Uncontrollable,
-          generator = SequenceGen.StepActionsGen(
-            configs = resources.map(r => r -> {_:SystemOverrides => pendingAction[IO](r)}).toMap,
-            post = (_, _) => Nil
           )
       }
     )

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -357,6 +357,12 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
               configs = resources.map(r => r -> pendingAction[IO](r)).toMap,
               post = _ => Nil
             )
+          ),
+          resources = resources,
+          _ => InstrumentSystem.Uncontrollable,
+          generator = SequenceGen.StepActionsGen(
+            configs = resources.map(r => r -> {_:SystemOverrides => pendingAction[IO](r)}).toMap,
+            post = (_, _) => Nil
           )
       }
     )

--- a/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/SeqexecServerLensesSpec.scala
@@ -28,8 +28,12 @@ final class SeqexecServerLensesSpec extends CatsSuite with SeqexecServerArbitrar
   // I tried to go down the rabbit hole with the Eqs, but it is not worth it for what they are used.
   implicit def actStateEq[F[_]]: Eq[Action.State[F]] = Eq.fromUniversalEquals
   implicit def actionEq[F[_]]: Eq[Action[F]] = Eq.by(x => (x.kind, x.state))
-  implicit def steppEq[F[_]]: Eq[HeaderExtraData => List[ParallelActions[F]]] = Eq.fromUniversalEquals
-  implicit def stepActionsGenEq[F[_]]: Eq[StepActionsGen[F]] = Eq.by(x => (x.pre, x.configs, x.post))
+  // Formally, to probe equality between two functions it must be probed that they produce the same result for all
+  // possible inputs. We settle for the `UniversalEquals` instead.
+  implicit def steplEq[F[_]]: Eq[HeaderExtraData => List[ParallelActions[F]]] = Eq.fromUniversalEquals
+  implicit def stepmEq[F[_]]: Eq[(HeaderExtraData, SystemOverrides) => List[ParallelActions[F]]] = Eq.fromUniversalEquals
+  implicit def stepnEq[F[_]]: Eq[SystemOverrides => Action[F]] = Eq.fromUniversalEquals
+  implicit def stepActionsGenEq[F[_]]: Eq[StepActionsGen[F]] = Eq.by(x => (x.configs, x.post))
   implicit def pndstepgEq[F[_]]: Eq[PendingStepGen[F]] = Eq.by(x => (x.id, x.config, x.resources, x
     .generator))
   implicit val skipstepgEq: Eq[SkippedStepGen] = Eq.by(x => (x.id, x.config))

--- a/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
+++ b/modules/seqexec/server/src/test/scala/seqexec/server/TestCommon.scala
@@ -170,78 +170,58 @@ object TestCommon {
 
   private val sm = SeqexecMetrics.build[IO](Site.GS, new CollectorRegistry()).unsafeRunSync()
 
-  private val gpiSim: IO[GpiController[IO]] = GpiClient
-    .simulatedGpiClient[IO]
-    .use(x =>
-      IO(
-        GpiController(
-          x,
-          new GdsClient(GdsClient.alwaysOkClient[IO], uri("http://localhost:8888/xmlrpc"))
-        )
-      )
-    )
+  private val gpiSim: IO[GpiController[IO]] = GpiClient.simulatedGpiClient[IO].use(x => IO(GpiController(x,
+    GdsClient(GdsClient.alwaysOkClient[IO], uri("http://localhost:8888/xmlrpc"))))
+  )
 
-  private val ghostSim: IO[GhostController[IO]] = GhostClient
-    .simulatedGhostClient[IO]
-    .use(x =>
-      IO(
-        GhostController(
-          x,
-          new GdsClient(GdsClient.alwaysOkClient[IO], uri("http://localhost:8888/xmlrpc"))
-        )
-      )
-    )
+  private val ghostSim : IO[GhostController[IO]] = GhostClient.simulatedGhostClient[IO].use(x => IO(GhostController(x,
+    GdsClient(GdsClient.alwaysOkClient[IO], uri("http://localhost:8888/xmlrpc"))))
+  )
 
-  val defaultSystems: Systems[IO] = (DhsClientSim[IO],
-                                     Flamingos2ControllerSim[IO],
-                                     GmosControllerSim.south[IO],
-                                     GmosControllerSim.north[IO],
-                                     GnirsControllerSim[IO],
-                                     GsaoiControllerSim[IO],
-                                     gpiSim,
-                                     ghostSim,
-                                     NiriControllerSim[IO],
-                                     NifsControllerSim[IO]
-  ).mapN { (dhs, f2, gmosS, gmosN, gnirs, gsaoi, gpi, ghost, niri, nifs) =>
-    Systems[IO](
-      OdbProxy(new Peer("localhost", 8443, null), new OdbProxy.DummyOdbCommands),
-      dhs,
-      TcsSouthControllerSim[IO],
-      TcsNorthControllerSim[IO],
-      GcalControllerSim[IO],
-      f2,
-      gmosS,
-      gmosN,
-      gnirs,
-      gsaoi,
-      gpi,
-      ghost,
-      niri,
-      nifs,
-      AltairControllerSim[IO],
-      GemsControllerSim[IO],
-      GuideConfigDb.constant[IO],
-      DummyTcsKeywordsReader[IO],
-      DummyGcalKeywordsReader[IO],
-      GmosKeywordReaderDummy[IO],
-      GnirsKeywordReaderDummy[IO],
-      NiriKeywordReaderDummy[IO],
-      NifsKeywordReaderDummy[IO],
-      GsaoiKeywordReaderDummy[IO],
-      AltairKeywordReaderDummy[IO],
-      GemsKeywordReaderDummy[IO],
-      DummyGwsKeywordsReader[IO]
-    )
-  }.unsafeRunSync()
+  val defaultSystems: Systems[IO] = (
+    DhsClientSim[IO],
+    Flamingos2ControllerSim[IO],
+    GmosControllerSim.south[IO],
+    GmosControllerSim.north[IO],
+    GnirsControllerSim[IO],
+    GsaoiControllerSim[IO],
+    gpiSim,
+    ghostSim,
+    NiriControllerSim[IO],
+    NifsControllerSim[IO]).mapN{ (dhs, f2, gmosS, gmosN, gnirs, gsaoi, gpi, ghost, niri, nifs) =>
+      Systems[IO](
+        OdbProxy(new Peer("localhost", 8443, null), new OdbProxy.DummyOdbCommands),
+        dhs,
+        TcsSouthControllerSim[IO],
+        TcsNorthControllerSim[IO],
+        GcalControllerSim[IO],
+        f2,
+        gmosS,
+        gmosN,
+        gnirs,
+        gsaoi,
+        gpi,
+        ghost,
+        niri,
+        nifs,
+        AltairControllerSim[IO],
+        GemsControllerSim[IO],
+        GuideConfigDb.constant[IO],
+        DummyTcsKeywordsReader[IO],
+        DummyGcalKeywordsReader[IO],
+        GmosKeywordReaderDummy[IO],
+        GnirsKeywordReaderDummy[IO],
+        NiriKeywordReaderDummy[IO],
+        NifsKeywordReaderDummy[IO],
+        GsaoiKeywordReaderDummy[IO],
+        AltairKeywordReaderDummy[IO],
+        GemsKeywordReaderDummy[IO],
+        DummyGwsKeywordsReader[IO]
+      )}.unsafeRunSync()
 
-  val seqexecEngine: SeqexecEngine[IO] =
-    SeqexecEngine.build(Site.GS, defaultSystems, defaultSettings, sm).unsafeRunSync()
+  val seqexecEngine: SeqexecEngine[IO] = SeqexecEngine.build(Site.GS, defaultSystems, defaultSettings, sm).unsafeRunSync()
 
-  def advanceOne(
-    q:   EventQueue[IO],
-    s0:  EngineState[IO],
-    put: IO[Unit]
-  ): IO[Option[EngineState[IO]]] =
+  def advanceOne(q: EventQueue[IO], s0: EngineState[IO], put: IO[Unit]): IO[Option[EngineState[IO]]] =
     advanceN(q, s0, put, 1L)
 
   def advanceN(
@@ -258,83 +238,71 @@ object TestCommon {
   val seqObsId2: Observation.Id = Observation.Id.unsafeFromString(seqId2)
   val seqId3: String            = "GS-2018B-Q-0-3"
   val seqObsId3: Observation.Id = Observation.Id.unsafeFromString(seqId3)
-  val clientId                  = ClientId(UUID.randomUUID)
+  val clientId = ClientId(UUID.randomUUID)
 
-  def sequence(id: Observation.Id): SequenceGen[IO] =
-    SequenceGen[IO](
-      id = id,
-      title = "",
-      instrument = Instrument.F2,
-      steps = List(
-        SequenceGen.PendingStepGen(
-          id = 1,
+  def sequence(id: Observation.Id): SequenceGen[IO] = SequenceGen[IO](
+    id = id,
+    title = "",
+    instrument = Instrument.F2,
+    steps = List(SequenceGen.PendingStepGen(
+      id = 1,
+      Monoid.empty[DataId],
+      config = CleanConfig.empty,
+      resources = Set.empty,
+      _ => InstrumentSystem.Uncontrollable,
+      generator = SequenceGen.StepActionsGen(
+        configs = Map(),
+        post = (_, _) => List(NonEmptyList.one(pendingAction[IO](Instrument.F2)))
+    )))
+  )
+
+  def sequenceNSteps(id: Observation.Id, n: Int): SequenceGen[IO] = SequenceGen[IO](
+    id = id,
+    title = "",
+    instrument = Instrument.F2,
+    steps =
+      List
+        .range(1, n)
+        .map(SequenceGen.PendingStepGen(
+          _,
           Monoid.empty[DataId],
           config = CleanConfig.empty,
           resources = Set.empty,
+          _ => InstrumentSystem.Uncontrollable,
           generator = SequenceGen.StepActionsGen(
-            pre = Nil,
-            configs = Map(),
-            post = _ => List(NonEmptyList.one(pendingAction[IO](Instrument.F2)))
-          )
+            configs = Map.empty,
+            post = (_, _) => List(NonEmptyList.one(pendingAction[IO](Instrument.F2)))
+    )))
+  )
+
+  def sequenceWithResources(id: Observation.Id, ins: Instrument, resources: Set[Resource]): SequenceGen[IO] = SequenceGen[IO](
+    id = id,
+    title = "",
+    instrument = ins,
+    steps = List(
+      SequenceGen.PendingStepGen(
+        id = 1,
+        Monoid.empty[DataId],
+        config = CleanConfig.empty,
+        resources = resources,
+        _ => InstrumentSystem.Uncontrollable,
+        generator = SequenceGen.StepActionsGen(
+          configs = resources.map(r => r -> {_:SystemOverrides => pendingAction[IO](r)}).toMap,
+          post = (_, _) => Nil
+        )
+      ),
+      SequenceGen.PendingStepGen(
+        id = 2,
+        Monoid.empty[DataId],
+        config = CleanConfig.empty,
+        resources = resources,
+        _ => InstrumentSystem.Uncontrollable,
+        generator = SequenceGen.StepActionsGen(
+          configs = resources.map(r => r -> {_:SystemOverrides => pendingAction[IO](r)}).toMap,
+          post = (_, _) =>Nil
         )
       )
     )
-
-  def sequenceNSteps(id: Observation.Id, n: Int): SequenceGen[IO] =
-    SequenceGen[IO](
-      id = id,
-      title = "",
-      instrument = Instrument.F2,
-      steps = List
-        .range(1, n)
-        .map(
-          SequenceGen.PendingStepGen(
-            _,
-            Monoid.empty[DataId],
-            config = CleanConfig.empty,
-            resources = Set.empty,
-            generator = SequenceGen.StepActionsGen(
-              pre = Nil,
-              configs = Map(),
-              post = _ => List(NonEmptyList.one(pendingAction[IO](Instrument.F2)))
-            )
-          )
-        )
-    )
-
-  def sequenceWithResources(
-    id:        Observation.Id,
-    ins:       Instrument,
-    resources: Set[Resource]
-  ): SequenceGen[IO] =
-    SequenceGen[IO](
-      id = id,
-      title = "",
-      instrument = ins,
-      steps = List(
-        SequenceGen.PendingStepGen(
-          id = 1,
-          Monoid.empty[DataId],
-          config = CleanConfig.empty,
-          resources = resources,
-          generator = SequenceGen.StepActionsGen(
-            pre = Nil,
-            configs = resources.map(r => r -> pendingAction[IO](r)).toMap,
-            post = _ => Nil
-          )
-        ),
-        SequenceGen.PendingStepGen(
-          id = 2,
-          Monoid.empty[DataId],
-          config = CleanConfig.empty,
-          resources = resources,
-          generator = SequenceGen.StepActionsGen(
-            pre = Nil,
-            configs = resources.map(r => r -> pendingAction[IO](r)).toMap,
-            post = _ => Nil
-          )
-        )
-      )
-    )
+  )
 
 }

--- a/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/seqexec/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -95,6 +95,22 @@ class SeqexecCommandRoutes[F[_]: Sync](
       se.setObserver(inputQueue, obsId, user, obs) *>
         Ok(s"Set observer name to '${obs.value}' for sequence ${obsId.format}")
 
+    case POST -> Root / ObsIdVar(obsId) / "tcsEnabled" / BooleanVar(tcsEnabled) as user =>
+      se.setTcsEnabled(inputQueue, obsId, user, tcsEnabled) *>
+        Ok(s"Set TCS enable flag to '${tcsEnabled}' for sequence ${obsId.format}")
+
+    case POST -> Root / ObsIdVar(obsId) / "gcalEnabled" / BooleanVar(gcalEnabled) as user =>
+      se.setGcalEnabled(inputQueue, obsId, user, gcalEnabled) *>
+        Ok(s"Set GCAL enable flag to '${gcalEnabled}' for sequence ${obsId.format}")
+
+    case POST -> Root / ObsIdVar(obsId) / "instEnabled" / BooleanVar(instEnabled) as user =>
+      se.setInstrumentEnabled(inputQueue, obsId, user, instEnabled) *>
+        Ok(s"Set instrument enable flag to '${instEnabled}' for sequence ${obsId.format}")
+
+    case POST -> Root / ObsIdVar(obsId) / "dhsEnabled" / BooleanVar(dhsEnabled) as user =>
+      se.setDhsEnabled(inputQueue, obsId, user, dhsEnabled) *>
+        Ok(s"Set DHS enable flag to '${dhsEnabled}' for sequence ${obsId.format}")
+
     case req @ POST -> Root / "iq" as user =>
       req.req.decode[ImageQuality](
         iq =>


### PR DESCRIPTION
This was way more complicated than I expected. The control code of all the systems follows a similar model. For each one exists a "Controller" class that encapsulates the interaction with the real system. I implemented the system override my switching each Controller class with one that does nothing, except logging some messages. I had to delay the creation of class instances that used these Controller classes, so I could reapply them each time I switch between the real Controller and the dumb one.
This was easy to do for TCS and GCAL, but it was a pain for the instruments. The main issue was that the interface `InstrumentSystem` had grown to encompass every instrument specific aspect. I had to split it to separate the parts that depended on a Controller. 