### PR TITLE
Rework of the main grid

### DIFF
--- a/modules/web/client/src/main/resources/less/style.less
+++ b/modules/web/client/src/main/resources/less/style.less
@@ -163,6 +163,10 @@ body {
   margin-bottom: 0 !important;
 }
 
+.SeqexecStyles-sequenceInfo {
+  background-color: none;
+  align-self: center;
+}
 .SeqexecStyles-headerSidebarStyle {
   border-width: 1px;
   border-style: solid;
@@ -171,74 +175,43 @@ body {
   .widerColumn;
 }
 
-.SeqexecStyles-emptyInstrumentTab {
-  min-height: 20.4em;
-}
-
-.SeqexecStyles-emptyInstrumentTabLogShown {
-  height: ~"calc(100vh - 39.9em)";
-}
-
-.SeqexecStyles-emptyInstrumentTabLogHidden {
-  height: ~"calc(100vh - 24.2em)";
+.ui.segment.SeqexecStyles-tabSegment {
+  padding: 0.4em;
+  margin-bottom: 0;
+  border-bottom: unset;
+  display: flex;
+  flex-direction: column;
 }
 
 .SeqexecStyles-tabSegment {
-  min-height: 20.4em;
-  padding: 0.4em !important;
-  margin-bottom: 0 !important;
+  flex-grow: 1;
+  flex-shrink: 1;
 }
 
-.SeqexecStyles-tabSegmentLogHidden {
-  height: ~"calc(100vh - 30.1em)";
+.SeqexecStyles-configTableControls {
+  margin-top: 0.2em;
+  margin-bottom: 0.2em;
+  display: flex;
+  justify-content: space-between;
+}
+.SeqexecStyles-tabControls {
 }
 
-.SeqexecStyles-tabSegmentLogShown {
-  height: ~"calc(100vh - 44.8em)";
+.SeqexecStyles-tabTable {
+  flex-grow: 1;
+  flex-shrink: 1;
 }
 
-.SeqexecStyles-tabSegmentUnauth {
-  min-height: 18.4em;
-  padding-right: 0.4em !important;
-  padding-left: 0.4em !important;
-  padding-top: 0.4em !important;
-  padding-bottom: 0.4em !important;
+.SeqexecStyles-sequencesControl {
+  margin-top: 0.2em;
+  margin-bottom: 0.2em;
+  display: flex;
+  justify-content: space-between;
 }
 
-.SeqexecStyles-tabSegmentLogHiddenUnauth {
-  height: ~"calc(100vh - 29.1em)";
-}
-
-.SeqexecStyles-tabSegmentLogShownUnauth {
-  height: ~"calc(100vh - 44.8em)";
-}
-
-.SeqexecStyles-tableContainer {
-  height: ~"calc(100% - 2.8em)";
-  margin-top: 1em;
-}
-
-.SeqexecStyles-tableContainerNoControls {
-  height: ~"calc(100% - 0.1em)";
-}
-
-.SeqexecStyles-sequencesArea {
-  .widerColumn;
-}
-
-.SeqexecStyles-controlButtons {
-  padding-bottom: 0.3em;
-}
-
-.SeqexecStyles-infoOnControl {
-  margin-top: 0.2em !important;
-}
-
-.SeqexecStyles-sequencesArea
-  > div
-  > .tabular.menu
-  > .SeqexecStyles-inactiveTabContent:last-child {
-  border-right: @border !important;
+.SeqexecStyles-sequencesTable {
+  flex-grow: 1;
+  flex-shrink: 1;
 }
 
 .SeqexecStyles-errorText {
@@ -257,16 +230,19 @@ body {
   .widerColumn;
 }
 
-.SeqexecStyles-logSecondarySegment {
-  .normalizedSegment;
-  padding-left: 0.4em !important;
-  padding-right: 0.4em !important;
+.ui.segment.SeqexecStyles-logSecondarySegment {
+  padding-left: 0.4em;
+  padding-right: 0.4em;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .SeqexecStyles-logControlRow {
   margin-top: 0.2em;
   margin-bottom: 0.2em;
-  padding: 0em !important;
+  padding: 0em;
+  display: flex;
+  justify-content: space-between;
 }
 
 .SeqexecStyles-logTableRow {
@@ -276,10 +252,18 @@ body {
   padding-top: 0em !important;
 }
 
+.ui.form .SeqexecStyles-selectorFields {
+  margin-bottom: 0px;
+  margin-top: 0px;
+}
+
 .SeqexecStyles-selectorFields {
-  float: right;
-  margin-bottom: 0px !important;
-  margin-top: 5px !important;
+  display: flex;
+}
+
+.ui.form .field.SeqexecStyles-logLevelBox {
+  margin-bottom: 0px;
+  margin-right: 1em;
 }
 
 .queueText() {
@@ -319,8 +303,9 @@ body {
   margin-bottom: -1em !important;
 }
 
-.SeqexecStyles-titleRow {
-  margin-bottom: 0em !important;
+.ui.header.SeqexecStyles-titleRow {
+  padding-top: 0.2em;
+  margin-bottom: 0.2em;
   &:after {
     top: 0px !important;
   }
@@ -398,20 +383,23 @@ body {
 }
 
 .SeqexecStyles-queueAreaRow {
-  .appSegment;
+  display: flex;
+  flex-direction: column;
 }
 
 .SeqexecStyles-queueArea {
-  .widerColumn;
+  width: 100%;
+  .mobileSegment;
 }
 
 .SeqexecStyles-headerSidebarArea {
-  .widerColumn;
+  width: 100%;
+  display: none;
+  padding-left: 0.5rem !important;
 }
 
 .SeqexecStyles-logArea {
-  margin-bottom: 3em;
-  .appSegment;
+  // .appSegment;
 }
 
 .SeqexecStyles-lowerRow {
@@ -738,7 +726,6 @@ body {
 }
 
 .stepWithBreakpoint(@line_color) {
-  // background-color: @background;
   background-image: linear-gradient(to right, @line_color 0px, @line_color);
   font-size: smaller !important;
   text-overflow: ellipsis;
@@ -1113,16 +1100,6 @@ body {
   padding-top: 0.5em !important;
   padding-bottom: 0.5em !important;
 }
-.ui.footer {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  height: 46px;
-  margin-bottom: 0;
-  margin-top: 0;
-  background-color: @background_color_5;
-  border-radius: unset;
-}
 .SeqexecStyles-stepsTable {
   background-image: linear-gradient(
       to bottom,
@@ -1137,6 +1114,7 @@ body {
   background-clip: content-box padding-box !important;
 }
 .SeqexecStyles-logTable {
+  margin-bottom: 0.2em;
   font-size: 1em;
 }
 .ReactVirtualized__Table__headerRow {
@@ -1322,10 +1300,41 @@ p.SeqexecStyles-confirmLine {
   font-weight: bold;
 }
 
+.SeqexecStyles-mainUI {
+  height: 100vh;
+  width: 100vw;
+  margin-bottom: 0px;
+  margin-top: 0px;
+  display: flex;
+  flex-direction: column;
+}
+
+.ui.menu.SeqexecStyles-footer {
+  margin-bottom: 0;
+  border-radius: unset;
+  margin-top: auto;
+  height: 46px;
+  width: 100%;
+  max-width: 100%;
+  min-height: 46px;
+}
+
 .SeqexecStyles-loginError {
   padding: 1em;
 }
 
+@media only screen and (min-width: 767px) {
+  .SeqexecStyles-queueAreaRow {
+    flex-direction: row;
+  }
+  .SeqexecStyles-queueArea {
+    width: 50%;
+  }
+  .SeqexecStyles-headerSidebarArea {
+    width: 50%;
+    display: block;
+  }
+}
 @media only screen and (max-width: 767px) {
   .SeqexecStyles-notInMobile {
     display: none !important;
@@ -1342,13 +1351,10 @@ p.SeqexecStyles-confirmLine {
   }
   .SeqexecStyles-tabSegment {
     .mobileSegment;
-    min-height: 32.3em;
-  }
-  .SeqexecStyles-sequencesArea {
-    .mobileSegment;
   }
   .SeqexecStyles-queueArea {
-    .mobileSegment;
+  }
+  .SeqexecStyles-headerSidebarArea {
   }
   .SeqexecStyles-logSegment {
     .mobileSegment;
@@ -1368,41 +1374,12 @@ p.SeqexecStyles-confirmLine {
   .SeqexecStyles-logArea {
     padding: 0em !important;
   }
-
-  .SeqexecStyles-tabSegmentLogHidden {
-    height: ~"calc(100vh - 21.1em)";
-  }
-
-  .SeqexecStyles-tabSegmentLogShown {
-    height: ~"calc(100vh - 35.8em)";
-  }
   .SeqexecStyles-emptyInstrumentTab {
     min-height: 25.4em;
-  }
-
-  .SeqexecStyles-emptyInstrumentTabLogShown {
-    height: ~"calc(100vh - 30.9em)";
-  }
-
-  .SeqexecStyles-emptyInstrumentTabLogHidden {
-    height: ~"calc(100vh - 16.1em)";
   }
   .SeqexecStyles-stepsListPaneUnauth {
     height: ~"calc(100% - 0em)";
     margin-top: 0.1em !important;
     margin-bottom: 0.1em !important;
-  }
-  .SeqexecStyles-tabSegmentUnauth {
-    padding-right: 0.1em !important;
-    padding-left: 0.1em !important;
-    padding-top: 0.1em !important;
-    padding-bottom: 0.1em !important;
-  }
-  .SeqexecStyles-tabSegmentLogHiddenUnauth {
-    height: ~"calc(100vh - 21.1em)";
-  }
-
-  .SeqexecStyles-tabSegmentLogShownUnauth {
-    height: ~"calc(100vh - 35.9em)";
   }
 }

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/ControlMenu.scala
@@ -92,6 +92,7 @@ object ControlMenu {
             )
           case None    =>
             MenuItem()(
+              helpButton,
               soundConnect(x => SoundControl(x())),
               loginButton(status.isConnected)
             )

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/Footer.scala
@@ -56,7 +56,7 @@ object Footer {
     .stateless
     .render_P(p =>
       Menu(
-        clazz = Css("footer"),
+        clazz = SeqexecStyles.Footer,
         inverted = true
       )(
         MenuItem(

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/LogArea.scala
@@ -30,18 +30,12 @@ import react.clipboard._
 import react.common._
 import react.common.implicits._
 import react.semanticui.collections.form.Form
-import react.semanticui.collections.form.FormField
-import react.semanticui.collections.form.FormGroup
-import react.semanticui.collections.grid.Grid
-import react.semanticui.collections.grid.GridColumn
-import react.semanticui.collections.grid.GridRow
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.LabelPosition
 import react.semanticui.elements.segment.Segment
 import react.semanticui.modules.checkbox.Checkbox
 import react.semanticui.sizes._
 import react.semanticui.textalignment._
-import react.semanticui.widths._
 import react.virtualized._
 import seqexec.common.FixedLengthBuffer
 import seqexec.model.enum.ServerLogLevel
@@ -53,13 +47,14 @@ import seqexec.web.client.model.GlobalLog
 import seqexec.web.client.model.SectionVisibilityState.SectionOpen
 import seqexec.web.client.reusability._
 import web.client.table._
+import react.semanticui.collections.form.FormCheckbox
 
 /**
  * Area to display a sequence's log
  */
 object CopyLogToClipboard {
   private val component = ScalaComponent
-    .builder[String]("CopyLogToClipboard")
+    .builder[String]
     .stateless
     .render_P { p =>
       CopyToClipboard(p)(
@@ -336,7 +331,7 @@ object LogArea {
     s => b.setStateL(State.levelLens(l))(s.some)
 
   private val component = ScalaComponent
-    .builder[Props]("LogArea")
+    .builder[Props]
     .initialState(State.Default)
     .render { b =>
       val p          = b.props
@@ -347,40 +342,32 @@ object LogArea {
         else IconDoubleUp
       val toggleText =
         (p.log.display === SectionOpen).fold("Hide Log", "Show Log")
-      GridColumn(width = Sixteen, clazz = SeqexecStyles.logSegment)(
-        Segment(secondary = true, clazz = SeqexecStyles.logSecondarySegment)(
-          Grid(
-            GridRow(clazz = SeqexecStyles.logControlRow)(
-              GridColumn(width = Six)(
-                Button(icon = true,
-                       labelPosition = LabelPosition.Left,
-                       compact = true,
-                       size = Small,
-                       onClick = SeqexecCircuit.dispatchCB(ToggleLogArea)
-                )(toggleIcon, toggleText)
-              ),
-              GridColumn(width = Ten)(
-                Form(
-                  FormGroup(clazz = SeqexecStyles.selectorFields)(
-                    s.selectedLevels.toTagMod { case (l, s) =>
-                      FormField(inline = true)(
-                        Checkbox(
-                          label = l.show,
-                          checked = s,
-                          onChangeE = (_: ReactMouseEvent, p: Checkbox.CheckboxProps) =>
-                            (onLevelChange(b, l)(p.checked.getOrElse(false)))
-                        )
-                      )
-                    }
-                  )
+      Segment(secondary = true, clazz = SeqexecStyles.logSecondarySegment)(
+        <.div(SeqexecStyles.logControlRow)(
+          Button(icon = true,
+                 labelPosition = LabelPosition.Left,
+                 compact = true,
+                 size = Small,
+                 onClick = SeqexecCircuit.dispatchCB(ToggleLogArea)
+          )(toggleIcon, toggleText),
+          Form(
+            <.div(SeqexecStyles.selectorFields)(
+              s.selectedLevels.toTagMod { case (l, s) =>
+                FormCheckbox(
+                  label = l.show,
+                  inline = true,
+                  clazz = SeqexecStyles.logLevelBox,
+                  checked = s,
+                  onChangeE = (_: ReactMouseEvent, p: Checkbox.CheckboxProps) =>
+                    (onLevelChange(b, l)(p.checked.getOrElse(false)))
                 )
-              ).when(p.log.display === SectionOpen)
-            ),
-            GridRow(clazz = SeqexecStyles.logTableRow)(
-              AutoSizer(AutoSizer.props(table(b), disableHeight = true, onResize = onResize(b)))
-            ).when(p.log.display === SectionOpen)
-          )
-        )
+              }
+            )
+          ).when(p.log.display === SectionOpen)
+        ),
+        <.div(SeqexecStyles.logSecondarySegment |+| SeqexecStyles.logTable)(
+          AutoSizer(AutoSizer.props(table(b), disableHeight = true, onResize = onResize(b)))
+        ).when(p.log.display === SectionOpen)
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -13,10 +13,8 @@ import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.Site
 import react.common._
 import react.common.implicits._
-import react.semanticui.collections.grid._
 import react.semanticui.elements.divider.Divider
 import react.semanticui.toasts._
-import react.semanticui.widths._
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.tabs.TabsArea
 import seqexec.web.client.model.Pages._
@@ -32,7 +30,7 @@ object AppTitle {
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
   private val component = ScalaComponent
-    .builder[Props]("SeqexecTitle")
+    .builder[Props]
     .stateless
     .render_P(p =>
       Divider(as = "h4",
@@ -63,14 +61,15 @@ object SeqexecMain {
   implicit val propsReuse: Reusability[Props] = Reusability.by(_.site)
 
   private val lbConnect               = SeqexecCircuit.connect(_.uiModel.loginBox)
-  private val logConnect              = SeqexecCircuit.connect(_.uiModel.globalLog)
   private val userNotificationConnect = SeqexecCircuit.connect(_.uiModel.notification)
   private val userPromptConnect       = SeqexecCircuit.connect(_.uiModel.userPrompt)
-  private val headerSideBarConnect    = SeqexecCircuit.connect(SeqexecCircuit.headerSideBarReader)
-  private val wsConnect               = SeqexecCircuit.connect(_.ws)
+
+  private val headerSideBarConnect = SeqexecCircuit.connect(SeqexecCircuit.headerSideBarReader)
+  private val logConnect           = SeqexecCircuit.connect(_.uiModel.globalLog)
+  private val wsConnect            = SeqexecCircuit.connect(_.ws)
 
   private val component = ScalaComponent
-    .builder[Props]("SeqexecUI")
+    .builder[Props]
     .stateless
     .render_P(p =>
       React.Fragment(
@@ -78,32 +77,25 @@ object SeqexecMain {
                                animation = SemanticAnimation.FadeUp,
                                clazz = SeqexecStyles.Toast
         ),
-        Grid(padded = GridPadded.Horizontally)(
-          GridRow(clazz = SeqexecStyles.shorterRow),
+        <.div(SeqexecStyles.MainUI)(
           wsConnect(ws => AppTitle(p.site, ws())),
-          GridRow(clazz = SeqexecStyles.shorterRow |+| SeqexecStyles.queueAreaRow)(
-            GridColumn(mobile = Sixteen,
-                       tablet = Ten,
-                       computer = Ten,
-                       clazz = SeqexecStyles.queueArea
-            )(
+          <.div(SeqexecStyles.queueAreaRow)(
+            <.div(SeqexecStyles.queueArea)(
               SessionQueueTableSection(p.ctl)
             ),
-            GridColumn(tablet = Six, computer = Six, clazz = SeqexecStyles.headerSideBarArea)(
+            <.div(SeqexecStyles.headerSideBarArea)(
               headerSideBarConnect(x => HeadersSideBar(x()))
             )
           ),
-          GridRow(clazz = SeqexecStyles.shorterRow)(
-            TabsArea(p.ctl, p.site)
-          ),
-          GridRow(clazz = SeqexecStyles.logArea)(
+          TabsArea(p.ctl, p.site),
+          <.div(SeqexecStyles.logArea)(
             logConnect(l => LogArea(p.site, l()))
-          )
+          ),
+            Footer(p.ctl, p.site)
         ),
         lbConnect(p => LoginBox(p())),
         userNotificationConnect(p => UserNotificationBox(p())),
-        userPromptConnect(p => UserPromptBox(p())),
-        Footer(p.ctl, p.site)
+        userPromptConnect(p => UserPromptBox(p()))
       )
     )
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/SeqexecMain.scala
@@ -91,7 +91,7 @@ object SeqexecMain {
           <.div(SeqexecStyles.logArea)(
             logConnect(l => LogArea(p.site, l()))
           ),
-            Footer(p.ctl, p.site)
+          Footer(p.ctl, p.site)
         ),
         lbConnect(p => LoginBox(p())),
         userNotificationConnect(p => UserNotificationBox(p())),

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/SeqexecStyles.scala
@@ -19,6 +19,24 @@ object SeqexecStyles {
   val TableRightPadding: Int        = 13
   val DefaultScrollBarWidth: Double = 15.0
 
+  val TabControls: Css =
+    Css("SeqexecStyles-tabControls")
+
+  val TabTable: Css =
+    Css("SeqexecStyles-tabTable")
+
+  val ConfigTableControls: Css =
+    Css("SeqexecStyles-configTableControls")
+
+  val SequencesControl: Css =
+    Css("SeqexecStyles-sequencesControl")
+
+  val MainUI: Css =
+    Css("SeqexecStyles-mainUI")
+
+  val Footer: Css =
+    Css("SeqexecStyles-footer")
+
   val LoginError: Css =
     Css("SeqexecStyles-loginError")
 
@@ -83,6 +101,8 @@ object SeqexecStyles {
 
   val fieldsNoBottom: Css = Css("SeqexecStyles-fieldsNoBottom")
 
+  val SequenceInfo: Css = Css("SeqexecStyles-sequenceInfo")
+
   val headerSideBarStyle: Css =
     Css("SeqexecStyles-headerSidebarStyle")
 
@@ -97,32 +117,7 @@ object SeqexecStyles {
 
   val tabSegment: Css = Css("SeqexecStyles-tabSegment")
 
-  val tabSegmentLogHidden: Css =
-    Css("SeqexecStyles-tabSegmentLogHidden")
-
-  val tabSegmentLogShown: Css =
-    Css("SeqexecStyles-tabSegmentLogShown")
-
-  val tabSegmentUnauth: Css =
-    Css("SeqexecStyles-tabSegmentUnauth")
-
-  val tabSegmentLogHiddenUnauth: Css =
-    Css("SeqexecStyles-tabSegmentLogHiddenUnauth")
-
-  val tabSegmentLogShownUnauth: Css =
-    Css("SeqexecStyles-tabSegmentLogShownUnauth")
-
-  val tableContainerNoControls: Css =
-    Css("SeqexecStyles-tableContainerNoControls")
-
-  val tableContainer: Css =
-    Css("SeqexecStyles-tableContainer")
-
-  val controlButtons: Css = Css("SeqexecStyles-controlButtons")
-
-  val infoOnControl: Css = Css("SeqexecStyles-infoOnControl")
-
-  val sequencesArea: Css = Css("SeqexecStyles-sequencesArea")
+  val SequenceControlButtons: Css = Css("SeqexecStyles-sequenceControlButtons")
 
   // Sometimes we need to manually add css
   val item: Css = Css("item")
@@ -149,7 +144,11 @@ object SeqexecStyles {
 
   val logTableRow: Css = Css("SeqexecStyles-logTableRow")
 
+  val logTable: Css = Css("SeqexecStyles-logTable")
+
   val selectorFields: Css = Css("SeqexecStyles-selectorFields")
+
+  val logLevelBox: Css = Css("SeqexecStyles-logLevelBox")
 
   val queueTextColumn: Css =
     Css("SeqexecStyles-queueTextColumn")

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
@@ -28,9 +28,7 @@ object TableContainer {
   private val component = ScalaComponent
     .builder[Props]("TableContainer")
     .stateless
-    .render_P(p =>
-      AutoSizer(AutoSizer.props(p.table, onResize = p.onResize))
-    )
+    .render_P(p => AutoSizer(AutoSizer.props(p.table, onResize = p.onResize)))
     .configure(Reusability.shouldComponentUpdate)
     .build
 

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/TableContainer.scala
@@ -11,17 +11,17 @@ import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
 import react.virtualized._
 
+final case class TableContainer(
+  hasControls: Boolean,
+  table:       Size => VdomElement,
+  onResize:    Size => Callback
+) extends ReactProps[TableContainer](TableContainer.component)
+
 /**
  * Container for several types of tables
  */
 object TableContainer {
-
-  // Todo use Reusable[A ~=> B]
-  final case class Props(
-    hasControls: Boolean,
-    table:       Size => VdomElement,
-    onResize:    Size => Callback
-  )
+  type Props = TableContainer
 
   implicit val reuse: Reusability[Props] = Reusability.never
 
@@ -29,11 +29,7 @@ object TableContainer {
     .builder[Props]("TableContainer")
     .stateless
     .render_P(p =>
-      <.div(
-        SeqexecStyles.tableContainer.when(p.hasControls),
-        SeqexecStyles.tableContainerNoControls.unless(p.hasControls),
-        AutoSizer(AutoSizer.props(p.table, onResize = p.onResize))
-      )
+      AutoSizer(AutoSizer.props(p.table, onResize = p.onResize))
     )
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueTabContent.scala
@@ -5,11 +5,11 @@ package seqexec.web.client.components.queue
 
 import cats.syntax.all._
 import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react.React
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
-import react.common.implicits._
 import react.semanticui.As
 import react.semanticui.collections.message.Message
 import react.semanticui.elements.segment.Segment
@@ -19,30 +19,30 @@ import seqexec.model.CalibrationQueueId
 import seqexec.web.client.circuit.SeqexecCircuit
 import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.icons._
-import seqexec.web.client.model.SectionVisibilityState
-import seqexec.web.client.model.SectionVisibilityState.SectionClosed
-import seqexec.web.client.model.SectionVisibilityState.SectionOpen
 import seqexec.web.client.model.TabSelected
 import seqexec.web.client.reusability._
 import seqexec.web.client.semanticui.dataTab
+import seqexec.web.client.model.SectionVisibilityState
+
+final case class CalQueueTabContent(
+  canOperate:   Boolean,
+  active:       TabSelected,
+  logDisplayed: SectionVisibilityState
+) extends ReactProps[CalQueueTabContent](CalQueueTabContent.component) {
+  protected[queue] val dayCalConnectOps =
+    SeqexecCircuit.connect(SeqexecCircuit.calQueueControlReader(CalibrationQueueId))
+  protected[queue] val dayCalConnect    =
+    SeqexecCircuit.connect(SeqexecCircuit.calQueueReader(CalibrationQueueId))
+
+  val isActive: Boolean =
+    active === TabSelected.Selected
+}
 
 /**
  * Content of the queue tab
  */
 object CalQueueTabContent {
-  final case class Props(
-    canOperate:   Boolean,
-    active:       TabSelected,
-    logDisplayed: SectionVisibilityState
-  ) {
-    protected[queue] val dayCalConnectOps =
-      SeqexecCircuit.connect(SeqexecCircuit.calQueueControlReader(CalibrationQueueId))
-    protected[queue] val dayCalConnect    =
-      SeqexecCircuit.connect(SeqexecCircuit.calQueueReader(CalibrationQueueId))
-
-    val isActive: Boolean =
-      active === TabSelected.Selected
-  }
+  type Props = CalQueueTabContent
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive[Props]
 
@@ -59,35 +59,27 @@ object CalQueueTabContent {
     .builder[Props]("CalQueueTabContent")
     .stateless
     .render_P { p =>
-      val tabClazz =
-        List(
-          SeqexecStyles.tabSegment,
-          SeqexecStyles.tabSegmentLogShown
-            .when_(p.logDisplayed === SectionOpen),
-          SeqexecStyles.tabSegmentLogHidden
-            .when_(p.logDisplayed === SectionClosed)
-        ).combineAll
-
       TabPane(active = p.isActive,
               as = As.Segment(Segment(attached = SegmentAttached.Attached, secondary = true)),
-              clazz = tabClazz
+              clazz = SeqexecStyles.tabSegment
       )(
         dataTab := "daycal",
-        <.div(
-          ^.height := "100%",
-          p.dayCalConnectOps(_() match {
-            case Some(x) => CalQueueToolbar(CalibrationQueueId, x)
-            case _       => <.div()
-          }).when(p.canOperate),
-          p.dayCalConnect(_() match {
-            case Some(x) =>
-              <.div(
-                ^.height := "100%",
-                CalQueueTable(CalQueueTable.Props(CalibrationQueueId, x))
-              )
-            case _       => defaultContent
-          })
-        ).when(p.isActive)
+        React
+          .Fragment(
+            <.div(SeqexecStyles.TabControls,
+                  p.dayCalConnectOps(_() match {
+                    case Some(x) => CalQueueToolbar(CalibrationQueueId, x)
+                    case _       => <.div()
+                  }).when(p.canOperate)
+            ),
+            <.div(SeqexecStyles.TabTable,
+                  p.dayCalConnect(_() match {
+                    case Some(x) =>
+                      CalQueueTable(CalibrationQueueId, x)
+                    case _       => defaultContent
+                  }).when(p.isActive)
+            )
+          )
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueToolbar.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/queue/CalQueueToolbar.scala
@@ -9,9 +9,7 @@ import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
-import react.semanticui.collections.grid._
 import react.semanticui.colors._
-import react.semanticui.floats._
 import seqexec.model.QueueId
 import seqexec.web.client.actions.RequestAllSelectedSequences
 import seqexec.web.client.actions.RequestClearAllCal
@@ -125,20 +123,14 @@ object CalQueueToolbar {
     )
 
   private val component = ScalaComponent
-    .builder[Props]("CalQueueToolbar")
+    .builder[Props]
     .render_P(p =>
-      Grid(
-        GridRow(clazz = SeqexecStyles.shorterRow)(
-          GridColumn(floated = Left)(
-            <.div(
-              SeqexecStyles.controlButtons,
-              addAllButton(p).unless(p.queueRunning),
-              clearAllButton(p).unless(p.queueRunning || p.control.queueSize === 0),
-              runButton(p).unless(p.queueRunning || p.control.queueSize === 0),
-              stopButton(p).when(p.queueRunning)
-            )
-          )
-        )
+      <.div(
+        SeqexecStyles.SequencesControl,
+        addAllButton(p).unless(p.queueRunning),
+        clearAllButton(p).unless(p.queueRunning || p.control.queueSize === 0),
+        runButton(p).unless(p.queueRunning || p.control.queueSize === 0),
+        stopButton(p).when(p.queueRunning)
       )
     )
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepConfigTable.scala
@@ -188,18 +188,14 @@ object StepConfigTable {
     .initialStateFromProps(_.startState)
     .render(b =>
       TableContainer(
-        TableContainer.Props(
-          true,
-          size =>
-            if (size.width.toInt > 0) {
-              Table(settingsTableProps(b, size),
-                    b.state.columnBuilder(size, colBuilder(b, size)): _*
-              )
-            } else {
-              <.div()
-            },
-          onResize = _ => Callback.empty
-        )
+        true,
+        size =>
+          if (size.width.toInt > 0) {
+            Table(settingsTableProps(b, size), b.state.columnBuilder(size, colBuilder(b, size)): _*)
+          } else {
+            <.div()
+          },
+        onResize = _ => Callback.empty
       )
     )
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -1030,27 +1030,25 @@ object StepsTable extends Columns {
   // Wire it up from VDOM
   def render($ : Scope): VdomElement =
     TableContainer(
-      TableContainer.Props(
-        $.props.hasControls,
-        size => {
-          val areaSize = Size(size.height, size.width.toInt - $.state.scrollBarWidth)
-          val ts       =
-            $.state.tableState
-              .columnBuilder(areaSize, colBuilder($, areaSize), $.props.columnWidths)
-              .map(_.vdomElement)
+      $.props.hasControls,
+      size => {
+        val areaSize = Size(size.height, size.width.toInt - $.state.scrollBarWidth)
+        val ts       =
+          $.state.tableState
+            .columnBuilder(areaSize, colBuilder($, areaSize), $.props.columnWidths)
+            .map(_.vdomElement)
 
-          if (size.width.toInt > 0)
-            ref
-              .component(stepsTableProps($)(size))(ts: _*)
-              .vdomElement
-          else
-            <.div()
-        },
-        onResize = s =>
-          $.modStateL(State.tableState)(
-            _.recalculateWidths(s, $.props.visibleColumns, $.props.columnWidths)
-          )
-      )
+        if (size.width.toInt > 0)
+          ref
+            .component(stepsTableProps($)(size))(ts: _*)
+            .vdomElement
+        else
+          <.div()
+      },
+      onResize = s =>
+        $.modStateL(State.tableState)(
+          _.recalculateWidths(s, $.props.visibleColumns, $.props.columnWidths)
+        )
     )
 
   def initialState(p: Props): State =

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceControl.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceControl.scala
@@ -19,7 +19,6 @@ import seqexec.web.client.actions.RequestRun
 import seqexec.web.client.actions.RequestSync
 import seqexec.web.client.actions.RunOptions
 import seqexec.web.client.circuit._
-import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.icons._
 import seqexec.web.client.model.CancelPauseOperation
 import seqexec.web.client.model.PauseOperation
@@ -137,7 +136,6 @@ object SequenceControl {
         val nextStepToRun                                  = nextStep.foldMap(_ + 1)
 
         <.div(
-          SeqexecStyles.controlButtons,
           List(
             // Sync button
             syncButton(id, p.canSync)

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbar.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceDefaultToolbar.scala
@@ -7,9 +7,6 @@ import diode.react.ReactConnectProxy
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
-import react.semanticui.collections.grid._
-import react.semanticui.floats._
-import react.semanticui.widths._
 import seqexec.model.Observation
 import seqexec.web.client.circuit._
 import seqexec.web.client.components.SeqexecStyles
@@ -34,25 +31,19 @@ object SequenceDefaultToolbar {
     .builder[Props]("SequenceDefaultToolbar")
     .stateless
     .render_P(p =>
-      Grid(
-        GridRow(columns = Two, clazz = SeqexecStyles.shorterRow)(
-          GridColumn(floated = Left,
-                     computer = Eight,
-                     tablet = Eight,
-                     only = GridOnly.Computer,
-                     clazz = SeqexecStyles.infoOnControl
-          )(
-            p.controlReader(_() match {
-              case Some(c) => SequenceControl(c)
-              case _       => <.div()
-            })
-          ),
-          GridColumn(floated = Right, clazz = SeqexecStyles.infoOnControl)(
-            p.observerReader(_() match {
-              case Some(p) => SequenceInfo(p)
-              case _       => <.div()
-            })
-          )
+      <.div(
+        SeqexecStyles.SequencesControl,
+        <.div(SeqexecStyles.SequenceControlButtons)(
+          p.controlReader(_() match {
+            case Some(c) => SequenceControl(c)
+            case _       => <.div()
+          })
+        ),
+        <.div(SeqexecStyles.SequenceInfo)(
+          p.observerReader(_() match {
+            case Some(p) => SequenceInfo(p)
+            case _       => <.div()
+          })
         )
       )
     )

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/SequenceInfo.scala
@@ -7,7 +7,6 @@ import cats.syntax.all._
 import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
-import react.semanticui.collections.form._
 import react.semanticui.colors._
 import react.semanticui.elements.label.Label
 import react.semanticui.sizes._
@@ -32,24 +31,15 @@ object SequenceInfo {
       .stateless
       .render_P { p =>
         val SequenceInfoFocus(isLogged, obsName, status, tName) = p.p
-        val unknownTargetName: TagMod                           =
-          Label(basic = true)(UnknownTargetName)
-        val targetName                                          = tName
+        val targetName: String                                  = tName
           .filter(_.nonEmpty)
-          .fold(unknownTargetName)(t => Label(basic = true)(t))
-        Form(
-          FormGroup(
-            SeqexecStyles.fieldsNoBottom,
-            FormField(
-              Label(color = Green, size = Medium)(IconCheckmark, "Sequence Complete")
-            ).when(status === SequenceState.Completed),
-            FormField(
-              Label(basic = true)(obsName)
-            ).when(isLogged),
-            FormField(
-              targetName
-            ).when(isLogged)
-          )
+          .getOrElse(UnknownTargetName)
+        <.div(
+          SeqexecStyles.SequenceInfo,
+          Label(color = Green, size = Medium)(IconCheckmark, "Sequence Complete")
+            .when(status === SequenceState.Completed),
+          Label(obsName).when(isLogged),
+          Label(targetName).when(isLogged)
         )
       }
       .build

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/toolbars/StepConfigToolbar.scala
@@ -12,15 +12,11 @@ import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.vdom.html_<^._
 import mouse.boolean._
 import react.common._
-import react.semanticui.collections.grid._
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.ButtonGroup
 import react.semanticui.elements.button.LabelPosition
 import react.semanticui.elements.label.Label
-import react.semanticui.floats._
 import react.semanticui.sizes._
-import react.semanticui.verticalalignment.Bottom
-import react.semanticui.widths._
 import seqexec.model.Observation
 import seqexec.model.RunningStep
 import seqexec.model.enum.Instrument
@@ -68,45 +64,42 @@ object StepConfigToolbar {
         SequenceConfigPage(p.instrument, p.id, p.step)
       }
 
-      Grid(
-        GridRow(columns = Three, clazz = SeqexecStyles.shorterRow)(
-          GridColumn(floated = Left, width = Two, clazz = SeqexecStyles.shorterFields)(
-            // Back to sequence button
-            p.router.link(sequencePage)(
-              Button(icon = true,
-                     labelPosition = LabelPosition.Left,
-                     onClick = p.router.setUrlAndDispatchCB(sequencePage)
-              )(IconChevronLeft, "Back")
-            )
-          ),
-          GridColumn(floated = Left, width = Six, verticalAlign = Bottom, only = GridOnly.Computer)(
-            p.sequenceConnect(_() match {
-              case Some(p) => SequenceInfo(p)
-              case _       => React.Fragment()
-            })
-          ),
-          GridColumn(floated = Right, width = Eight, clazz = SeqexecStyles.shorterFields)(
-            ButtonGroup(clazz = Css("right floated"))(
-              // Previous step button
-              (p.step > 0).option(
-                p.router.link(prevStepPage)(
-                  Button(icon = true,
-                         labelPosition = LabelPosition.Left,
-                         onClick = p.router.setUrlAndDispatchCB(prevStepPage)
-                  )(IconChevronLeft, "Prev")
-                )
-              ),
-              Label(size = Large, clazz = SeqexecStyles.labelAsButton)(
-                RunningStep.fromInt(p.step, p.total).getOrElse(RunningStep.Zero).show
-              ),
-              // Next step button
-              (p.step < p.total - 1).option(
-                p.router.link(nextStepPage)(
-                  Button(icon = true,
-                         labelPosition = LabelPosition.Right,
-                         onClick = p.router.setUrlAndDispatchCB(nextStepPage)
-                  )(IconChevronRight, "Next")
-                )
+      <.div(
+        SeqexecStyles.ConfigTableControls,
+        <.div(SeqexecStyles.SequenceControlButtons)(
+          // Back to sequence button
+          p.router.link(sequencePage)(
+            Button(icon = true,
+                   labelPosition = LabelPosition.Left,
+                   onClick = p.router.setUrlAndDispatchCB(sequencePage)
+            )(IconChevronLeft, "Back")
+          )
+        ),
+        p.sequenceConnect(_() match {
+          case Some(p) => SequenceInfo(p)
+          case _       => React.Fragment()
+        }),
+        <.div(SeqexecStyles.SequenceInfo)(
+          ButtonGroup(clazz = Css("right floated"))(
+            // Previous step button
+            (p.step > 0).option(
+              p.router.link(prevStepPage)(
+                Button(icon = true,
+                       labelPosition = LabelPosition.Left,
+                       onClick = p.router.setUrlAndDispatchCB(prevStepPage)
+                )(IconChevronLeft, "Prev")
+              )
+            ),
+            Label(size = Large, clazz = SeqexecStyles.labelAsButton)(
+              RunningStep.fromInt(p.step, p.total).getOrElse(RunningStep.Zero).show
+            ),
+            // Next step button
+            (p.step < p.total - 1).option(
+              p.router.link(nextStepPage)(
+                Button(icon = true,
+                       labelPosition = LabelPosition.Right,
+                       onClick = p.router.setUrlAndDispatchCB(nextStepPage)
+                )(IconChevronRight, "Next")
               )
             )
           )

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTabContent.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/tabs/SequenceTabContent.scala
@@ -10,7 +10,6 @@ import japgolly.scalajs.react.ScalaComponent
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
-import react.common.implicits._
 import react.semanticui.As
 import react.semanticui.elements.segment.Segment
 import react.semanticui.elements.segment.SegmentAttached
@@ -22,8 +21,6 @@ import seqexec.web.client.components.sequence.steps.StepsTable
 import seqexec.web.client.components.sequence.toolbars.SequenceDefaultToolbar
 import seqexec.web.client.components.sequence.toolbars.StepConfigToolbar
 import seqexec.web.client.model.Pages.SeqexecPages
-import seqexec.web.client.model.SectionVisibilityState.SectionClosed
-import seqexec.web.client.model.SectionVisibilityState.SectionOpen
 import seqexec.web.client.reusability._
 import seqexec.web.client.semanticui._
 
@@ -65,10 +62,7 @@ object SequenceTabContent {
     p.content.tableType match {
       case StepsTableTypeSelection.StepsTableSelected =>
         p.stepsConnect { x =>
-          <.div(
-            ^.height := "100%",
-            StepsTable(p.router, p.content.canOperate, x())
-          )
+          StepsTable(p.router, p.content.canOperate, x())
         }
 
       case StepsTableTypeSelection.StepConfigTableSelected(i) =>
@@ -90,39 +84,20 @@ object SequenceTabContent {
     }
 
   protected val component = ScalaComponent
-    .builder[Props]("SequenceTabContent")
+    .builder[Props]
     .stateless
     .render_P { p =>
-      val canOperate   = p.content.canOperate
-      val instrument   = p.content.instrument
-      val logDisplayed = p.content.logDisplayed
-
-      val tabClazz =
-        List(
-          SeqexecStyles.tabSegment.when_(canOperate),
-          SeqexecStyles.tabSegmentLogShown
-            .when_(canOperate && logDisplayed === SectionOpen),
-          SeqexecStyles.tabSegmentLogHidden
-            .when_(canOperate && logDisplayed === SectionClosed),
-          SeqexecStyles.tabSegmentUnauth.when_(!canOperate),
-          SeqexecStyles.tabSegmentLogShownUnauth
-            .when_(!canOperate && logDisplayed === SectionOpen),
-          SeqexecStyles.tabSegmentLogHiddenUnauth
-            .when_(!canOperate && logDisplayed === SectionClosed)
-        ).combineAll
-
-      TabPane(active = p.content.isActive,
-              as = As.Segment(
-                Segment(compact = true, attached = SegmentAttached.Attached, secondary = true)
-              ),
-              clazz = tabClazz
+      val instrument = p.content.instrument
+      TabPane(
+        active = p.content.isActive,
+        as = As.Segment(
+          Segment(compact = true, attached = SegmentAttached.Attached, secondary = true)
+        ),
+        clazz = SeqexecStyles.tabSegment
       )(
         dataTab := instrument.show,
-        <.div(
-          ^.height := "100%",
-          toolbar(p),
-          stepsTable(p)
-        ).when(p.content.isActive)
+        <.div(SeqexecStyles.TabControls, toolbar(p).when(p.content.canOperate)),
+        <.div(SeqexecStyles.TabTable, stepsTable(p).when(p.content.isActive))
       )
     }
     .configure(Reusability.shouldComponentUpdate)

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/tabs/TabsArea.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/tabs/TabsArea.scala
@@ -10,10 +10,7 @@ import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.Site
 import react.common._
-import react.semanticui.collections.grid.GridColumn
-import react.semanticui.widths._
 import seqexec.web.client.circuit._
-import seqexec.web.client.components.SeqexecStyles
 import seqexec.web.client.components.queue.CalQueueTabContent
 import seqexec.web.client.model.Pages.SeqexecPages
 import seqexec.web.client.reusability._
@@ -34,18 +31,16 @@ object TabsArea {
     .builder[Props]("TabsArea")
     .stateless
     .render_P(p =>
-      GridColumn(width = Sixteen, clazz = SeqexecStyles.sequencesArea)(
+      React.Fragment(
         SeqexecTabs(p.router),
         tabsConnect(x =>
           React
             .Fragment(
               x().toList.collect {
-                case t: SequenceTabContentFocus =>
+                case t: SequenceTabContentFocus if t.isActive =>
                   SequenceTabContent(p.router, t): VdomNode
-                case t                          =>
-                  CalQueueTabContent(
-                    CalQueueTabContent.Props(t.canOperate, t.active, t.logDisplayed)
-                  ): VdomNode
+                case t if t.isActive                          =>
+                  CalQueueTabContent(t.canOperate, t.active, t.logDisplayed): VdomNode
               }: _*
             )
         )


### PR DESCRIPTION
The seqexec used semantic ui grids to organize the main layout but that was more complicated than needed, especially when making the UI responsive

This PR changes all that making it use flexbox instead