### PR TITLE
SEQNG-1193 Remember that Gems was paused because of a Sky between steps.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/tcs/Gaos.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/Gaos.scala
@@ -74,6 +74,11 @@ object Gaos {
       case b: FixedPauseCondition => PauseConditionSet(offsetO, fixed + b)
     }
 
+    def -(v: PauseCondition): PauseConditionSet = v match {
+      case _: OffsetMove          => PauseConditionSet(none, fixed)
+      case b: FixedPauseCondition => PauseConditionSet(offsetO, fixed - b)
+    }
+
     def contains(v: FixedPauseCondition): Boolean = fixed.contains(v)
 
   }

--- a/modules/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSuite.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/GuideConfigDbSuite.scala
@@ -49,7 +49,8 @@ final class GuideConfigDbSuite extends munit.FunSuite {
       M1GuideConfig.M1GuideOn(M1Source.PWFS1),
       M2GuideConfig.M2GuideOn(ComaOption.ComaOff, Set(TipTiltSource.PWFS1))
     ),
-    None
+    None,
+    gemsSkyPaused = false
   )
 
   val rawJson2: String          = """
@@ -87,7 +88,8 @@ final class GuideConfigDbSuite extends munit.FunSuite {
       M1GuideConfig.M1GuideOn(M1Source.PWFS1),
       M2GuideConfig.M2GuideOn(ComaOption.ComaOn, Set(TipTiltSource.PWFS1))
     ),
-    Some(Left(Lgs(strap = true, sfo = true, starPos = (Millimeters(-5.0), Millimeters(3.0)))))
+    Some(Left(Lgs(strap = true, sfo = true, starPos = (Millimeters(-5.0), Millimeters(3.0))))),
+    gemsSkyPaused = false
   )
 
   val rawJson3: String          = """
@@ -138,7 +140,8 @@ final class GuideConfigDbSuite extends munit.FunSuite {
           OIUsage.DontUse
         )
       )
-    )
+    ),
+    gemsSkyPaused = false
   )
 
   test("GuideConfigDb provide decoders") {


### PR DESCRIPTION
Seqexec interacts with GeMS by notifying it of events that may affect GeMS AO and guiding. There are three types defined:
1. Sky: Natural guide stars will not be available for an observation because of a big offset.
2. Dither: The telescope will apply an offset.
3. Filter: It only applies if using GSAOI ODGW. ODGW will be unavailable.

Seqexec sends events when the conditions appears (pause command) and when it ends (resume command). Dither is the easiest one, because both events occur inside the setup of a single step (pause Dither -> TCS offset -> resume Dither -> observe).

The issue this PR fixes is for the Sky events. The pause Sky event must be sent before the first unguided exposure, and the resume Sky must be sent before the next guided one. I added a mechanism to carry the state of sending the sky event between steps.

Something similar must be done for the "pause Filter" event when implementing support for ODGW.