### PR TITLE
SEQNG-1232 Fixed useAo flag being checked for night time calibrations.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsControllerEpicsCommon.scala
@@ -648,9 +648,9 @@ object TcsControllerEpicsCommon {
       for {
         s0 <- tcsConfigRetriever.retrieveBaseConfiguration
         _  <- SeqexecFailure
-                .Execution("Found useAo set for non AO step.")
+                .Execution("Found useAo set for non AO step using PWFS2.")
                 .raiseError[F, Unit]
-                .whenA(s0.useAo)
+                .whenA(s0.useAo && subsystems.contains(Subsystem.PWFS2) && tcs.gds.pwfs2.isActive)
         s1 <- guideOff(subsystems, s0, tcs)
         s2 <- sysConfig(s1)
         _  <- guideOn(subsystems, s2, tcs)


### PR DESCRIPTION
Night time calibrations inside an Altair sequence were failing with the error "Found useAo set for non AO step".
The issue was that class `TcsControllerEpicsCommon` is used to setup the telescope for calibrations and non AO observations, but assumed that the useAo flags must be always off. That is not the case for calibrations inside an Altair sequence.
Strictly speaking, having the useAo flag set is only an error if PWFS2 is used. I used this fact to make the check more restricted.