### PR TITLE
SEQNG-1235 CRFOLLOW value is now calculated from TCS rotator tracking frame

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -263,6 +263,8 @@ trait TcsEpics[F[_]] {
 
   def crFollow: F[Int]
 
+  def crTrackingFrame: F[String]
+
   def sourceATarget: Target[F]
 
   val pwfs1Target: Target[F]
@@ -1007,6 +1009,10 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
   override def carouselMode: F[String] = safeAttributeF(tcsState.getStringAttribute("cguidmod"))
 
   override def crFollow: F[Int] = safeAttributeSIntF(tcsState.getIntegerAttribute("crfollow"))
+
+  override def crTrackingFrame: F[String] = safeAttributeF(
+    tcsState.getStringAttribute("rotTrackFrame")
+  )
 
   override def sourceATarget: Target[F] = new Target[F] {
     override def epoch: F[String] = safeAttributeF(tcsState.getStringAttribute("sourceAEpoch"))

--- a/modules/server/src/main/scala/seqexec/server/tcs/TrackingFrame.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TrackingFrame.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.tcs
+
+import cats.Eq
+import cats.implicits._
+
+sealed trait TrackingFrame
+
+object TrackingFrame {
+  case object AzimuthElevation extends TrackingFrame
+  case object FK5              extends TrackingFrame
+  case object FK4              extends TrackingFrame
+  case object Apparent         extends TrackingFrame
+  case class Other(name: String) extends TrackingFrame
+
+  implicit var trackingFrameEq: Eq[TrackingFrame] = Eq.instance {
+    case (AzimuthElevation, AzimuthElevation) => true
+    case (FK5, FK5)                           => true
+    case (FK4, FK4)                           => true
+    case (Apparent, Apparent)                 => true
+    case (Other(a), Other(b))                 => a === b
+    case _                                    => false
+  }
+
+  def fromString(v: String): TrackingFrame = v match {
+    case "AZEL_TOPO" => AzimuthElevation
+    case "FK5"       => FK5
+    case "FK4"       => FK4
+    case "Appt"      => Apparent
+    case _           => Other(v)
+  }
+}

--- a/modules/server/src/test/scala/seqexec/server/tcs/TcsSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TcsSpec.scala
@@ -6,7 +6,6 @@ package seqexec.server.tcs
 import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 import edu.gemini.seqexec.server.tcs.{ BinaryOnOff, BinaryYesNo }
-import monocle.law.discipline.PrismTests
 
 /**
  * Tests Tcs typeclasses
@@ -15,5 +14,4 @@ final class TcsSpec extends CatsSuite with TcsArbitraries {
   checkAll("Eq[BinaryYesNo]", EqTests[BinaryYesNo].eqv)
   checkAll("Eq[BinaryOnOff]", EqTests[BinaryOnOff].eqv)
   checkAll("Eq[CRFollow]", EqTests[CRFollow].eqv)
-  checkAll("Prism[Int, CRFollow]", PrismTests(CRFollow.fromInt))
 }

--- a/modules/server/src/test/scala/seqexec/server/tcs/TestTcsEpics.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TestTcsEpics.scala
@@ -466,6 +466,8 @@ class TestTcsEpics[F[_]: Sync](
 
   override def crFollow: F[Int] = state.get.map(_.crFollow)
 
+  override def crTrackingFrame: F[String] = state.get.map(_.crTrackingFrame)
+
   override def sourceATarget: Target[F] = targetGetters(state, State.sourceATarget.asGetter)
 
   override val pwfs1Target: Target[F] = targetGetters(state, State.pwfs1Target.asGetter)
@@ -800,6 +802,7 @@ object TestTcsEpics {
     airmassEnd:               Double,
     carouselMode:             String,
     crFollow:                 Int,
+    crTrackingFrame:          String,
     sourceATarget:            TargetVals,
     pwfs1Target:              TargetVals,
     pwfs2Target:              TargetVals,
@@ -1079,6 +1082,7 @@ object TestTcsEpics {
     airmassEnd = 0.0,
     carouselMode = "",
     crFollow = 0,
+    crTrackingFrame = "",
     sourceATarget = TargetVals.default,
     pwfs1Target = TargetVals.default,
     pwfs2Target = TargetVals.default,


### PR DESCRIPTION
The change affects the keyword CRFOLLOW, set for GPI, GeMS and Altair.