### PR TITLE
SEQNG-1238 Fixed problem with trying to run a sequence from a step other than the first

### DIFF
--- a/modules/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -62,7 +62,7 @@ class Engine[F[_]: MonadError[?[_], Throwable]: Logger, S, U](stateL: Engine.Sta
           ) =>
         val steps     = seq.toSequence.steps
           .takeWhile(_.id =!= step)
-          .mapFilter(p => p.status.canRunFrom.option(p.id))
+          .mapFilter(p => (!p.status.isFinished).option(p.id))
         val withSkips = steps.foldLeft[Sequence.State[F]](seq) { case (s, i) =>
           s.setSkipMark(i, v = true)
         }

--- a/modules/model/shared/src/main/scala/seqexec/model/Step.scala
+++ b/modules/model/shared/src/main/scala/seqexec/model/Step.scala
@@ -169,8 +169,6 @@ object Step {
 
     def wasSkipped: Boolean = s.status.wasSkipped
 
-    def canRunFrom: Boolean = s.status.canRunFrom
-
     def canConfigure: Boolean = s.status.canConfigure
 
     def isMultiLevel: Boolean =

--- a/modules/model/shared/src/main/scala/seqexec/model/StepState.scala
+++ b/modules/model/shared/src/main/scala/seqexec/model/StepState.scala
@@ -6,17 +6,17 @@ package seqexec.model
 import cats.Eq
 import cats.syntax.all._
 
-sealed abstract class StepState(val canRunFrom: Boolean) extends Product with Serializable
+sealed abstract class StepState extends Product with Serializable
 
 object StepState {
 
-  case object Pending   extends StepState(true)
-  case object Completed extends StepState(false)
-  case object Skipped   extends StepState(false)
-  case object Aborted   extends StepState(true)
-  final case class Failed(msg: String) extends StepState(true)
-  case object Running   extends StepState(false)
-  case object Paused    extends StepState(true)
+  case object Pending   extends StepState
+  case object Completed extends StepState
+  case object Skipped   extends StepState
+  case object Aborted   extends StepState
+  final case class Failed(msg: String) extends StepState
+  case object Running   extends StepState
+  case object Paused    extends StepState
 
   implicit val equal: Eq[StepState] =
     Eq.instance {

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepProgressControl.scala
@@ -173,7 +173,7 @@ object StepProgressCell {
         props.step.id,
         props.tabOperations.resourceInFlight(props.step.id),
         props.tabOperations.startFromRequested
-      ).when(props.step.canRunFrom && props.clientStatus.canOperate),
+      ).when(!props.step.isFinished && props.clientStatus.canOperate),
       <.div(
         SeqexecStyles.specialStateLabel,
         if (props.stateSummary.isAC) {


### PR DESCRIPTION
Running from a step other than the first is accomplished by marking all the previous steps as skipped, and then starting the sequence normally. Of course, the process of marking the previous steps as skipped left completed or already skipped steps untouched. The bug was that partially run steps were also left untouched, so when calling start on the sequence, it founded this unrun step not skipped, and would start from it.
After the changes some code became redundant. I remove it.