### PR TITLE
SEQNG-1244 Used sequence value for keyword DETNROI.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -53,14 +53,16 @@ object GmosHeader {
         )
 
       private def roiKeywords: F[List[KeywordBag => F[KeywordBag]]] =
-        gmosReader.roiValues.map {
-          _.flatMap { case (i, rv) =>
-            List(
-              KeywordName.fromTag(s"DETRO${i}X").map(buildInt32(rv.xStart.pure[F], _)),
-              KeywordName.fromTag(s"DETRO${i}XS").map(buildInt32(rv.xSize.pure[F], _)),
-              KeywordName.fromTag(s"DETRO${i}Y").map(buildInt32(rv.yStart.pure[F], _)),
-              KeywordName.fromTag(s"DETRO${i}YS").map(buildInt32(rv.ySize.pure[F], _))
-            ).flattenOption
+        gmosObsReader.numberOfROI.attempt.flatMap { roiCnt =>
+          gmosReader.roiValues(roiCnt.toOption).map {
+            _.flatMap { case (i, rv) =>
+              List(
+                KeywordName.fromTag(s"DETRO${i}X").map(buildInt32(rv.xStart.pure[F], _)),
+                KeywordName.fromTag(s"DETRO${i}XS").map(buildInt32(rv.xSize.pure[F], _)),
+                KeywordName.fromTag(s"DETRO${i}Y").map(buildInt32(rv.yStart.pure[F], _)),
+                KeywordName.fromTag(s"DETRO${i}YS").map(buildInt32(rv.ySize.pure[F], _))
+              ).flattenOption
+            }
           }
         }
 
@@ -139,7 +141,7 @@ object GmosHeader {
                         KeywordName.EXPOSURE
             ),
             buildInt32(gmosReader.adcUsed, KeywordName.ADCUSED),
-            buildInt32(gmosReader.detNRoi, KeywordName.DETNROI)
+            buildInt32(gmosObsReader.numberOfROI, KeywordName.DETNROI)
           ) ::: adcKeywords ::: roiKeywords ::: nsKeywords
         )
 


### PR DESCRIPTION
This is a workaround for the problem with the GMOS status channel that gives the number of ROIs used. Instead of relying on that channel, the number of ROIs given in the sequence is used. That number is also used to determine how many ROI parameter sets must be written in the header.