### PR TITLE
SEQNG-1248 Mark GMOS ROI CAD when changing unconnected parameters.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/GmosHeader.scala
@@ -53,16 +53,14 @@ object GmosHeader {
         )
 
       private def roiKeywords: F[List[KeywordBag => F[KeywordBag]]] =
-        gmosObsReader.numberOfROI.attempt.flatMap { roiCnt =>
-          gmosReader.roiValues(roiCnt.toOption).map {
-            _.flatMap { case (i, rv) =>
-              List(
-                KeywordName.fromTag(s"DETRO${i}X").map(buildInt32(rv.xStart.pure[F], _)),
-                KeywordName.fromTag(s"DETRO${i}XS").map(buildInt32(rv.xSize.pure[F], _)),
-                KeywordName.fromTag(s"DETRO${i}Y").map(buildInt32(rv.yStart.pure[F], _)),
-                KeywordName.fromTag(s"DETRO${i}YS").map(buildInt32(rv.ySize.pure[F], _))
-              ).flattenOption
-            }
+        gmosReader.roiValues(none).map {
+          _.flatMap { case (i, rv) =>
+            List(
+              KeywordName.fromTag(s"DETRO${i}X").map(buildInt32(rv.xStart.pure[F], _)),
+              KeywordName.fromTag(s"DETRO${i}XS").map(buildInt32(rv.xSize.pure[F], _)),
+              KeywordName.fromTag(s"DETRO${i}Y").map(buildInt32(rv.yStart.pure[F], _)),
+              KeywordName.fromTag(s"DETRO${i}YS").map(buildInt32(rv.ySize.pure[F], _))
+            ).flattenOption
           }
         }
 
@@ -141,7 +139,7 @@ object GmosHeader {
                         KeywordName.EXPOSURE
             ),
             buildInt32(gmosReader.adcUsed, KeywordName.ADCUSED),
-            buildInt32(gmosObsReader.numberOfROI, KeywordName.DETNROI)
+            buildInt32(gmosReader.detNRoi, KeywordName.DETNROI)
           ) ::: adcKeywords ::: roiKeywords ::: nsKeywords
         )
 


### PR DESCRIPTION
When configuring GMOS, whenever the number of roy or binning is changed, the ROI CAD is marked. This is necessary because the ROI configuration depends on those parameters, but they are not connected to the ROI CAD.
I also went back in the workaround for the DETNROI keyword, because at the point the value is read from GMOS, it already got the updated value.