### PR TITLE
SEQNG-1252 Increased estimated readout time for observe timeout.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/flamingos2/Flamingos2ControllerEpics.scala
@@ -107,7 +107,7 @@ trait Flamingos2Encoders {
 
 object Flamingos2ControllerEpics extends Flamingos2Encoders {
 
-  val ReadoutTimeout: FiniteDuration = FiniteDuration(30, SECONDS)
+  val ReadoutTimeout: FiniteDuration = FiniteDuration(120, SECONDS)
   val DefaultTimeout: FiniteDuration = FiniteDuration(60, SECONDS)
   val ConfigTimeout: FiniteDuration  = FiniteDuration(400, SECONDS)
 

--- a/modules/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/GmosControllerEpics.scala
@@ -628,7 +628,7 @@ object GmosControllerEpics extends GmosEncoders {
   }
 
   val DefaultTimeout: FiniteDuration = FiniteDuration(60, SECONDS)
-  val ReadoutTimeout: FiniteDuration = FiniteDuration(90, SECONDS)
+  val ReadoutTimeout: FiniteDuration = FiniteDuration(120, SECONDS)
   val ConfigTimeout: FiniteDuration  = FiniteDuration(600, SECONDS)
 
 }

--- a/modules/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/gnirs/GnirsControllerEpics.scala
@@ -378,6 +378,6 @@ object GnirsControllerEpics extends GnirsEncoders {
     }
 
   private val DefaultTimeout: FiniteDuration = FiniteDuration(60, SECONDS)
-  private val ReadoutTimeout: FiniteDuration = FiniteDuration(30, SECONDS)
+  private val ReadoutTimeout: FiniteDuration = FiniteDuration(120, SECONDS)
   private val ConfigTimeout: FiniteDuration  = FiniteDuration(240, SECONDS)
 }

--- a/modules/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/nifs/NifsControllerEpics.scala
@@ -391,7 +391,7 @@ object NifsControllerEpics extends NifsEncoders {
       )
 
     def calcObserveTimeout(cfg: DCConfig): FiniteDuration = {
-      val SafetyPadding = 30.seconds
+      val SafetyPadding = 120.seconds
 
       FiniteDuration((calcTotalExposureTime(cfg) + SafetyPadding).toMillis, MILLISECONDS)
     }

--- a/modules/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/niri/NiriControllerEpics.scala
@@ -270,7 +270,7 @@ object NiriControllerEpics extends NiriEncoders {
         epicsSys.minIntegration.map { t =>
           val MinIntTime    = t.seconds
           val CoaddOverhead = 2.5
-          val TotalOverhead = 30.seconds
+          val TotalOverhead = 120.seconds
 
           FiniteDuration(
             ((cfg.exposureTime + MinIntTime) * cfg.coadds.toDouble * CoaddOverhead + TotalOverhead).toMillis,


### PR DESCRIPTION
The logs show instances of timeout errors where the actual time taken by GMOS to finish the observation was close to the timeout time used by Seqexec, probably causing a false timeout error. I increased the timeout for GMOS.
GMOS is not the only instrument that has frequent observation timeouts. Because of that, I also increased the timeout for other instruments. That would either fix the timeout problem, or allows us to discard that they are caused by a too short waiting time.