### PR TITLE
SEQNG-1258 Altair: execute mirror flattening before reenabling loops.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -303,6 +303,10 @@ object AltairControllerEpics {
       val resume: Option[F[Unit]] = (resumeReasons.contains(ResumeCondition.GaosGuideOn) &&
         (pauseReasons.contains(PauseCondition.GaosGuideOff) || !currCfg.aoLoop)).option {
         L.debug("Resuming Altair guiding") *>
+          epicsAltair.btoLoopControl.setActive("ON") *>
+          epicsAltair.btoLoopControl.post(DefaultTimeout) *>
+          epicsTcs.aoFlatten.mark *>
+          epicsTcs.aoFlatten.post(DefaultTimeout) *>
           epicsTcs.aoCorrect.setCorrections(CorrectionsOn) *>
           epicsTcs.aoFlatten.mark *>
           epicsTcs.targetFilter.setShortCircuit(TargetFilterOpen) *>


### PR DESCRIPTION
Seqexec was trying to flatten Altair DM at the same time it was enabling Altair guiding, which caused a problem. That was an error when translating the old Tcl code. With this PR the two commands are sequenced. Also, I noticed that the Tcl code also enables the BTO loop on resuming, something I forgot to put in the Web Seqexec. That was also fixed.