### PR TITLE
SEQNG-1262 Restored retries for DHS keyword messages.

### DIFF
--- a/app/seqexec-server-gn/src/main/resources/app.conf
+++ b/app/seqexec-server-gn/src/main/resources/app.conf
@@ -64,5 +64,5 @@ seqexec-engine {
   epicsCaAddrList = "10.2.2.255 10.2.10.21 10.2.126.101"
   readRetries = 4
   ioTimeout = 4 seconds
-  dhsTimeout = 20 seconds
+  dhsTimeout = 24 seconds
 }

--- a/app/seqexec-server-gs/src/main/resources/app.conf
+++ b/app/seqexec-server-gs/src/main/resources/app.conf
@@ -61,7 +61,7 @@ seqexec-engine {
   epicsCaAddrList = "172.17.2.255 172.17.3.255 172.17.102.130 172.17.105.20 172.16.102.130 172.17.106.111 172.17.105.37 172.17.107.50 172.17.55.101 172.17.101.101 172.17.65.255 172.17.102.139 172.17.102.138"
   readRetries = 4
   ioTimeout = 4 seconds
-  dhsTimeout = 20 seconds
+  dhsTimeout = 24 seconds
   gpiUrl = "failover:(tcp://172.17.107.50:61616)?timeout=4000"
   gpiGDS = "http://172.17.107.50:8888/xmlrpc"
   ghostUrl = "failover:(tcp://172.16.111.22:61616)?timeout=4000"

--- a/modules/server/src/main/scala/seqexec/server/keywords/DhsClientHttp.scala
+++ b/modules/server/src/main/scala/seqexec/server/keywords/DhsClientHttp.scala
@@ -85,8 +85,8 @@ class DhsClientHttp[F[_]: Concurrent](base: Client[F], baseURI: Uri)(implicit ti
       ),
       baseURI / id / "keywords"
     )
-    val cl  = if (finalFlag) base else clientWithRetry
-    cl.expect[Either[SeqexecFailure, Unit]](req)(jsonOf[F, Either[SeqexecFailure, Unit]])
+    clientWithRetry
+      .expect[Either[SeqexecFailure, Unit]](req)(jsonOf[F, Either[SeqexecFailure, Unit]])
       .attemptT
       .leftMap(SeqexecExceptionWhile("sending keywords to DHS", _))
       .flatMap(EitherT.fromEither(_))


### PR DESCRIPTION
Actually, it was disabled only for the last package (the "final" one).
I also adjusted the DHS timeout after analyzing the record of request service time. 24s is the worst case.