### PR TITLE
SEQNG-1268 Log reasons to change TCS configuration.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -231,6 +231,11 @@ object TcsController {
       tag[OffsetP](((x * -1 * iaa.cos) + y * iaa.sin) * FOCAL_PLANE_SCALE),
       tag[OffsetQ](((x * -1 * iaa.sin) - y * iaa.cos) * FOCAL_PLANE_SCALE)
     )
+
+    def ~=(other: FocalPlaneOffset): Boolean =
+      math.pow((x - other.x).toMillimeters, 2) + math.pow((y - other.y).toMillimeters,
+                                                          2
+      ) <= FocalPlaneOffset.ToleranceSquared
   }
 
   object FocalPlaneOffset {
@@ -238,6 +243,8 @@ object TcsController {
 
     def fromInstrumentOffset(o: InstrumentOffset, iaa: Angle): FocalPlaneOffset =
       o.toFocalPlaneOffset(iaa)
+
+    val ToleranceSquared: Double = 1e12
   }
 
   trait OffsetP
@@ -249,6 +256,7 @@ object TcsController {
       tag[OffsetX](((p * -1 * iaa.cos) - q * iaa.sin) / FOCAL_PLANE_SCALE),
       tag[OffsetY]((p * iaa.sin - q * iaa.cos) / FOCAL_PLANE_SCALE)
     )
+
   }
 
   object InstrumentOffset {

--- a/modules/server/src/main/scala/seqexec/server/tcs/package.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/package.scala
@@ -49,6 +49,10 @@ package tcs {
 
   }
 
+  sealed case class WithDebug[A](self: A, debug: String) {
+    def mapDebug(f: String => String): WithDebug[A] = this.copy(debug = f(debug))
+  }
+
 }
 
 package object tcs {
@@ -76,5 +80,9 @@ package object tcs {
     Eq[Int].contramap(_.ordinal())
 
   def tagIso[B, T]: Iso[B @@ T, B] = Iso.apply[B @@ T, B](x => x)(tag[T](_))
+
+  implicit class WithDebugOps[A](v: A) {
+    def withDebug(msg: String): WithDebug[A] = WithDebug(v, msg)
+  }
 
 }


### PR DESCRIPTION
Log every EPICS parameter changed in TCS. The log message has the parameter name, old value, and new value.
The new messages are output only if seqexec.server.tcs.trace is defined. 