### PR TITLE
FR-72094: increased timeout when waiting for science fold in-position.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/tcs/package.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/package.scala
@@ -59,8 +59,8 @@ package object tcs {
   val BottomPort: Int  = 1
   val InvalidPort: Int = 0
 
-  val tcsTimeout: FiniteDuration = FiniteDuration(60, SECONDS)
-  val agTimeout: FiniteDuration  = FiniteDuration(60, SECONDS)
+  val tcsTimeout: FiniteDuration = FiniteDuration(90, SECONDS)
+  val agTimeout: FiniteDuration  = FiniteDuration(90, SECONDS)
 
   val NonStopExposures = -1
 


### PR DESCRIPTION
This is a small PR to adjust the timeout used when waiting for the science fold to get in position. It happens that sometimes it takes longer than 60 seconds.