### PR TITLE
SEQNG-1270: Check selected OI before trying to park it.

### DIFF
--- a/modules/server/src/main/resources/Tcs.xml
+++ b/modules/server/src/main/resources/Tcs.xml
@@ -1204,6 +1204,12 @@
             <type>DOUBLE</type>
             <description>Guide star Y</description>
         </attribute>
+        <attribute name="oiName">
+            <channel>oi:name</channel>
+            <type>STRING</type>
+            <description>selected OI</description>
+            <top>ag</top>
+        </attribute>
         <attribute name="oiParked">
             <channel>oi:probeParked</channel>
             <type>INTEGER</type>

--- a/modules/server/src/main/scala/seqexec/server/tcs/BasicEpicsTcsConfig.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/BasicEpicsTcsConfig.scala
@@ -28,6 +28,7 @@ final case class BaseEpicsTcsConfig(
   pwfs1:                GuiderConfig,
   pwfs2:                GuiderConfig,
   oiwfs:                GuiderConfig,
+  oiName:               String,
   telescopeGuideConfig: TelescopeGuideConfig,
   aoFold:               AoFold,
   useAo:                Boolean,

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -327,19 +327,20 @@ object TcsConfigRetriever {
 
     override def retrieveBaseConfiguration: F[BaseEpicsTcsConfig] =
       for {
-        iaa   <- getIAA
-        offX  <- getOffsetX
-        offY  <- getOffsetY
-        wl    <- getWavelength
-        p1    <- getPwfs1
-        p2    <- getPwfs2
-        oi    <- getOiwfs
-        tgc   <- getGuideConfig
-        aof   <- getAoFold
-        useAo <- getUseAo
-        sf    <- getScienceFoldPosition
-        hr    <- getHrwfsPickupPosition
-        ports <- getInstrumentPorts
+        iaa    <- getIAA
+        offX   <- getOffsetX
+        offY   <- getOffsetY
+        wl     <- getWavelength
+        p1     <- getPwfs1
+        p2     <- getPwfs2
+        oi     <- getOiwfs
+        oiName <- epicsSys.oiName
+        tgc    <- getGuideConfig
+        aof    <- getAoFold
+        useAo  <- getUseAo
+        sf     <- getScienceFoldPosition
+        hr     <- getHrwfsPickupPosition
+        ports  <- getInstrumentPorts
       } yield BaseEpicsTcsConfig(
         iaa,
         FocalPlaneOffset(tag[OffsetX](offX), tag[OffsetY](offY)),
@@ -347,6 +348,7 @@ object TcsConfigRetriever {
         p1,
         p2,
         oi,
+        oiName,
         tgc,
         aof,
         useAo,

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsEpics.scala
@@ -166,6 +166,8 @@ trait TcsEpics[F[_]] {
 
   def p2Parked: F[Boolean]
 
+  def oiName: F[String]
+
   def oiParked: F[Boolean]
 
   def pwfs1On: F[BinaryYesNo]
@@ -840,6 +842,8 @@ final class TcsEpicsImpl[F[_]: Async](epicsService: CaService, tops: Map[String,
 
   override def p2Parked: F[Boolean] = safeAttributeSIntF(tcsState.getIntegerAttribute("p2Parked"))
     .map(_ =!= 0)
+
+  override def oiName: F[String] = safeAttributeF(tcsState.getStringAttribute("oiName"))
 
   override def oiParked: F[Boolean] = safeAttributeSIntF(tcsState.getIntegerAttribute("oiParked"))
     .map(_ =!= 0)

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -145,7 +145,9 @@ object TcsNorthControllerEpicsAo {
           setAltairProbe(subsystems, current.aowfs, tcs.gds.aoguide.tracking),
           commonController.setOiwfsProbe(EpicsTcsAoConfig.base)(subsystems,
                                                                 current.base.oiwfs.tracking,
-                                                                tcs.gds.oiwfs.tracking
+                                                                tcs.gds.oiwfs.tracking,
+                                                                current.base.oiName,
+                                                                tcs.inst.instrument
           ),
           commonController.setScienceFold(EpicsTcsAoConfig.base)(subsystems,
                                                                  current,

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -506,7 +506,9 @@ object TcsSouthControllerEpicsAo {
           ),
           commonController.setOiwfsProbe(EpicsTcsAoConfig.base)(subsystems,
                                                                 current.base.oiwfs.tracking,
-                                                                tcs.gds.oiwfs.tracking
+                                                                tcs.gds.oiwfs.tracking,
+                                                                current.base.oiName,
+                                                                tcs.inst.instrument
           ),
           commonController.setScienceFold(EpicsTcsAoConfig.base)(subsystems,
                                                                  current,

--- a/modules/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsCommonSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsCommonSpec.scala
@@ -63,6 +63,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
     GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
     GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
     GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
+    "None",
     TelescopeGuideConfig(MountGuideOption.MountGuideOff,
                          M1GuideConfig.M1GuideOff,
                          M2GuideConfig.M2GuideOff
@@ -669,6 +670,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
     oiwfsOn = BinaryYesNo.Yes,
     sfName = "gmos3",
     oiwfsProbeGuideConfig = ProbeGuideConfigVals(1, 0, 0, 1),
+    oiName = "GMOS",
     gmosPort = 3,
     comaCorrect = "On"
   )
@@ -775,6 +777,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
         m1GuideSource = "OIWFS",
         m2oiGuide = "ON",
         oiParked = false,
+        oiName = "GMOS",
         sfName = "gmos3",
         gmosPort = 3
       )

--- a/modules/server/src/test/scala/seqexec/server/tcs/TcsNorthControllerEpicsAoSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TcsNorthControllerEpicsAoSpec.scala
@@ -34,12 +34,13 @@ class TcsNorthControllerEpicsAoSpec extends AnyFlatSpec with PrivateMethodTester
       GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
       GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
       GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
+      "None",
       TelescopeGuideConfig(MountGuideOption.MountGuideOff,
                            M1GuideConfig.M1GuideOff,
                            M2GuideConfig.M2GuideOff
       ),
       AoFold.Out,
-      false,
+      useAo = false,
       None,
       HrwfsPickupPosition.OUT,
       InstrumentPorts(

--- a/modules/server/src/test/scala/seqexec/server/tcs/TestTcsEpics.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TestTcsEpics.scala
@@ -380,6 +380,8 @@ class TestTcsEpics[F[_]: Sync](
 
   override def p2Parked: F[Boolean] = state.get.map(_.p2Parked)
 
+  override def oiName: F[String] = state.get.map(_.oiName)
+
   override def oiParked: F[Boolean] = state.get.map(_.oiParked)
 
   override def pwfs1On: F[BinaryYesNo] = state.get.map(_.pwfs1On)
@@ -770,6 +772,7 @@ object TestTcsEpics {
     p1Parked:                 Boolean,
     p2Parked:                 Boolean,
     oiParked:                 Boolean,
+    oiName:                   String,
     pwfs1On:                  BinaryYesNo,
     pwfs2On:                  BinaryYesNo,
     oiwfsOn:                  BinaryYesNo,
@@ -1052,6 +1055,7 @@ object TestTcsEpics {
     p1Parked = true,
     p2Parked = true,
     oiParked = true,
+    oiName = "None",
     pwfs1On = BinaryYesNo.No,
     pwfs2On = BinaryYesNo.No,
     oiwfsOn = BinaryYesNo.No,
@@ -1142,28 +1146,28 @@ object TestTcsEpics {
     g2GuideConfig = ProbeGuideConfigVals.default,
     g3GuideConfig = ProbeGuideConfigVals.default,
     g4GuideConfig = ProbeGuideConfigVals.default,
-    m1GuideCmd = TestEpicsCommand1.State[String](false, ""),
-    m2GuideCmd = TestEpicsCommand1.State[String](false, ""),
-    m2GuideModeCmd = TestEpicsCommand1.State[String](false, ""),
-    m2GuideConfigCmd = TestEpicsCommand3.State[String, String, String](false, "", "", ""),
-    mountGuideCmd = TestEpicsCommand2.State[String, String](false, "", ""),
+    m1GuideCmd = TestEpicsCommand1.State[String](mark = false, ""),
+    m2GuideCmd = TestEpicsCommand1.State[String](mark = false, ""),
+    m2GuideModeCmd = TestEpicsCommand1.State[String](mark = false, ""),
+    m2GuideConfigCmd = TestEpicsCommand3.State[String, String, String](mark = false, "", "", ""),
+    mountGuideCmd = TestEpicsCommand2.State[String, String](mark = false, "", ""),
     pwfs1ProbeGuideConfigCmd =
-      TestEpicsCommand4.State[String, String, String, String](false, "", "", "", ""),
+      TestEpicsCommand4.State[String, String, String, String](mark = false, "", "", "", ""),
     pwfs2ProbeGuideConfigCmd =
-      TestEpicsCommand4.State[String, String, String, String](false, "", "", "", ""),
+      TestEpicsCommand4.State[String, String, String, String](mark = false, "", "", "", ""),
     oiwfsProbeGuideConfigCmd =
-      TestEpicsCommand4.State[String, String, String, String](false, "", "", "", ""),
-    pwfs1ProbeFollowCmd = TestEpicsCommand1.State[String](false, ""),
-    pwfs2ProbeFollowCmd = TestEpicsCommand1.State[String](false, ""),
-    oiwfsProbeFollowCmd = TestEpicsCommand1.State[String](false, ""),
-    offsetACmd = TestEpicsCommand2.State[Double, Double](false, 0.0, 0.0),
-    wavelSourceACmd = TestEpicsCommand1.State[Double](false, 0.0),
+      TestEpicsCommand4.State[String, String, String, String](mark = false, "", "", "", ""),
+    pwfs1ProbeFollowCmd = TestEpicsCommand1.State[String](mark = false, ""),
+    pwfs2ProbeFollowCmd = TestEpicsCommand1.State[String](mark = false, ""),
+    oiwfsProbeFollowCmd = TestEpicsCommand1.State[String](mark = false, ""),
+    offsetACmd = TestEpicsCommand2.State[Double, Double](mark = false, 0.0, 0.0),
+    wavelSourceACmd = TestEpicsCommand1.State[Double](mark = false, 0.0),
     pwfs1ParkCmd = false,
     pwfs2ParkCmd = false,
     oiwfsParkCmd = false,
-    pwfs1ObserveCmd = TestEpicsCommand1.State[Int](false, -1),
-    pwfs2ObserveCmd = TestEpicsCommand1.State[Int](false, -1),
-    oiwfsObserveCmd = TestEpicsCommand1.State[Int](false, -1),
+    pwfs1ObserveCmd = TestEpicsCommand1.State[Int](mark = false, -1),
+    pwfs2ObserveCmd = TestEpicsCommand1.State[Int](mark = false, -1),
+    oiwfsObserveCmd = TestEpicsCommand1.State[Int](mark = false, -1),
     pwfs1StopObserveCmd = false,
     pwfs2StopObserveCmd = false,
     oiwfsStopObserveCmd = false


### PR DESCRIPTION
Seqexec was trying to park the OI probe when none was selected in the A&G Sequencer. The result was a no operation that wasted a couple of seconds on each step. This PR makes sure that Seqexec parks the OI only if it selected in the A&G Sequencer.