### PR TITLE
FR-72196 Removed name translation of major bodies for target check

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/SeqexecEngine.scala
+++ b/modules/server/src/main/scala/seqexec/server/SeqexecEngine.scala
@@ -288,7 +288,7 @@ object SeqexecEngine {
         .map { seqTarget =>
           systems.tcsKeywordReader.sourceATarget.objectName.map { tcsTarget =>
             (seqTarget =!= tcsTarget).option(
-              TargetCheckOverride(UserPrompt.Discrepancy(seqTarget, tcsTarget))
+              TargetCheckOverride(UserPrompt.Discrepancy(tcsTarget, seqTarget))
             )
           }
         }
@@ -300,17 +300,6 @@ object SeqexecEngine {
      */
     private def extractTargetName(config: CleanConfig): Option[String] = {
       val BasePositionKey    = "Base:name"
-      val SolarSystemObjects = Map(
-        ("199", "Mercury"),
-        ("299", "Venus"),
-        ("301", "Moon"),
-        ("499", "Mars"),
-        ("599", "Jupiter"),
-        ("699", "Saturn"),
-        ("799", "Uranus"),
-        ("899", "Neptune"),
-        ("999", "Pluto")
-      )
       val baseName           = config.extractTelescopeAs[String](BasePositionKey).toOption
       val EphemerisExtension = ".eph"
 
@@ -318,7 +307,7 @@ object SeqexecEngine {
         if (x.endsWith(EphemerisExtension)) {
           x.dropRight(EphemerisExtension.length)
         } else {
-          SolarSystemObjects.getOrElse(x, x)
+          x
         }
       }
     }

--- a/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -505,31 +505,6 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
     }).unsafeRunSync()
   }
 
-  it should "pass the target check for solar objects" in {
-    val systems = systemsWithTargetName("Jupiter")
-
-    val seq = testTargetSequence("599", 1, List(ObsClass.SCIENCE), List(SCIENCE_OBSERVE_TYPE))
-
-    val s0 = ODBSequencesLoader
-      .loadSequenceEndo[IO](seqObsId1, seq, executeEngine)
-      .apply(EngineState.default[IO])
-
-    (for {
-      sm            <- SeqexecMetrics.build[IO](Site.GS, new CollectorRegistry())
-      seqexecEngine <- SeqexecEngine.build(Site.GS, systems, defaultSettings, sm)
-      q             <- Queue.bounded[IO, executeEngine.EventType](10)
-      sf            <- advanceOne(
-                         q,
-                         s0,
-                         seqexecEngine.start(q, seqObsId1, UserDetails("", ""), clientId, RunOverride.Default)
-                       )
-    } yield inside(
-      sf.flatMap(EngineState.sequenceStateIndex[IO](seqObsId1).getOption).map(_.status)
-    ) { case Some(status) =>
-      assert(status.isRunning)
-    }).unsafeRunSync()
-  }
-
   it should "start sequence that fails target check if forced" in {
     val systems = systemsWithTargetName("other")
 


### PR DESCRIPTION
I removed the translation once used to fix the target check for major bodies, because it is not needed anymore and is causing problems when in the OT, the Horizon code is used instead of the body name. 