### PR TITLE
SEQNG-1277 Fixed control of target filter for Altair.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -117,7 +117,7 @@ object TcsNorthControllerEpicsAo {
       def executeTargetFilterConf(filterEnabled: Boolean): F[Unit] =
         L.debug(s"${filterEnabled.fold("Activating", "Deactivating")} target filtering.") *>
           epicsSys.targetFilter.setShortCircuit(
-            filterEnabled.fold(TargetFilterClosed, TargetFilterOpen)
+            filterEnabled.fold(TargetFilterShortcircuitOpen, TargetFilterShortcircuitClosed)
           ) *>
           epicsSys.targetFilter.post(TcsControllerEpicsCommon.DefaultTimeout) *>
           L.debug(s"Target filtering ${filterEnabled.fold("activated", "deactivated")}.")
@@ -469,7 +469,7 @@ object TcsNorthControllerEpicsAo {
     aowfs: ProbeTrackingConfig
   )
 
-  val TargetFilterOpen: String   = "Open"
-  val TargetFilterClosed: String = "Closed"
+  val TargetFilterShortcircuitOpen: String   = "Open"
+  val TargetFilterShortcircuitClosed: String = "Closed"
 
 }

--- a/modules/server/src/test/scala/seqexec/server/altair/AltairControllerEpicsSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/altair/AltairControllerEpicsSpec.scala
@@ -152,7 +152,7 @@ class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
     }
   }
 
-  test("AltairControllerEpics should pause and not resume NGS AO for unguided stap with offset") {
+  test("AltairControllerEpics should pause and not resume NGS AO for unguided step with offset") {
     val altairEpics = buildAltairController[IO](
       TestAltairEpics.defaultState.copy(
         aoLoop = true,


### PR DESCRIPTION
The logic to control target filter was inverted. This PR fixes it.
In the TCL Seqexec the criteria to decide if an offset could be applied without pausing guiding depended on if the current control matrix needed to be updated or not. In the Web Seqexec, I had also a check on the offset displacement magnitude. I removed it to make it like the Tcl Seqexec.