### PR TITLE
SEQNG-1240 Support refreshing after sync

### DIFF
--- a/modules/web/client/src/main/resources/less/style.less
+++ b/modules/web/client/src/main/resources/less/style.less
@@ -990,7 +990,6 @@ body {
 
 .SeqexecStyles-selectedIcon {
   .queueText;
-  margin-bottom: 7px !important;
   margin-right: 0px !important;
 }
 

--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -360,9 +360,11 @@ final case class StepsTable(
 
   val configTableState: TableState[StepConfigTable.TableColumn] =
     stepsTable.configTableState
+
   // Find out if offsets should be displayed
-  val offsetsDisplay: OffsetsDisplay                            = stepsList.offsetsDisplay
-  private def showProp(p: InstrumentProperties): Boolean        =
+  val offsetsDisplay: OffsetsDisplay = stepsList.offsetsDisplay
+
+  private def showProp(p: InstrumentProperties): Boolean =
     steps.exists(s => s.instrument.displayItems.contains(p))
 
   val showOffsets: Boolean =
@@ -406,6 +408,17 @@ final case class StepsTable(
 
   val visibleColumns: TableColumn => Boolean =
     shownForInstrument.map(_.column).contains _
+
+  def visibleColumnValues(s: Step) = (exposure(s),
+                                      disperser(s),
+                                      filter(s),
+                                      fpuOrMask(s),
+                                      camera(s),
+                                      s.deckerName,
+                                      s.imagingMirrorName,
+                                      s.observingMode,
+                                      s.readMode
+  )
 
   val extractors = List[(TableColumn, Step => Option[String])](
     (ExposureColumn, exposure),
@@ -470,7 +483,7 @@ object StepsTable extends Columns {
   object StepSummary {
     def fromStep(step: Step): StepSummary = StepSummary(step.id, step.status, step.breakpoint)
 
-    implicit val stepSummaryEq: Eq[StepSummary] = Eq.fromUniversalEquals
+    implicit val stepSummaryEq: Eq[StepSummary] = Eq.by(x => (x.id, x.status, x.breakpoint))
   }
 
   @Lenses
@@ -526,10 +539,16 @@ object StepsTable extends Columns {
     )
   }
 
-  implicit val propsReuse: Reusability[Props]      =
+  implicit val propsReuse: Reusability[Props] =
     Reusability.by(x =>
-      (x.canOperate, x.selectedStep, x.stepsList, x.tabOperations.resourceRunRequested)
+      (x.canOperate,
+       x.selectedStep,
+       x.stepsList,
+       x.stepsList.map(x.visibleColumnValues),
+       x.tabOperations.resourceRunRequested
+      )
     )
+
   implicit val tcReuse: Reusability[TableColumn]   = Reusability.byRef
   implicit val scrollBarReuse: Reusability[Double] = Reusability.double(1.0)
   implicit val stateReuse: Reusability[State]      =


### PR DESCRIPTION
Sync should update the table column's values if e.g. the exposure time changed in the backend. The current caching mechanism was too aggressive and that didn't happen.