### PR TITLE
SEQNG-1279 Restore M2 guide after offset for Altair LGS mode.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -335,13 +335,18 @@ object AltairControllerEpics {
       val updatedCfg = pause.wasPaused.fold(ttgsOffEndo(currCfg), currCfg)
       val resume     = resumeLgsMode(strap, sfo, updatedCfg, adjustedResumeReasons)
 
-      AltairPauseResume(pause.pauseAction,
-                        pause.keepGuiding,
-                        pause.filterTarget,
-                        resume.some,
-                        GuideCapabilities(canGuideM2 = false, canGuideM1 = true),
-                        none,
-                        forceFreeze
+      AltairPauseResume(
+        pause.pauseAction,
+        pause.keepGuiding,
+        pause.filterTarget,
+        resume.some,
+        GuideCapabilities(
+          canGuideM2 =
+            (strap || sfo) && adjustedResumeReasons.contains(ResumeCondition.GaosGuideOn),
+          canGuideM1 = true
+        ),
+        none,
+        forceFreeze
       )
     }
 

--- a/modules/server/src/test/scala/seqexec/server/altair/AltairControllerEpicsSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/altair/AltairControllerEpicsSpec.scala
@@ -68,6 +68,10 @@ class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
       assert(ao2.isEmpty)
       assert(tcs2.isEmpty)
       assert(!r.forceFreeze)
+      assert(r.guideWhilePaused.canGuideM2)
+      assert(r.guideWhilePaused.canGuideM1)
+      assert(r.restoreOnResume.canGuideM2)
+      assert(r.restoreOnResume.canGuideM1)
     }
   }
 
@@ -110,6 +114,10 @@ class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
       assert(ao2.isEmpty)
       assert(tcs2.contains(AoCorrectCmd("ON", 1)))
       assert(!r.forceFreeze)
+      assert(!r.guideWhilePaused.canGuideM2)
+      assert(!r.guideWhilePaused.canGuideM1)
+      assert(r.restoreOnResume.canGuideM2)
+      assert(r.restoreOnResume.canGuideM1)
     }
   }
 
@@ -149,6 +157,10 @@ class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
       assert(ao2.isEmpty)
       assert(!tcs2.contains(AoCorrectCmd("ON", 1)))
       assert(!r.forceFreeze)
+      assert(!r.guideWhilePaused.canGuideM2)
+      assert(!r.guideWhilePaused.canGuideM1)
+      assert(!r.restoreOnResume.canGuideM2)
+      assert(!r.restoreOnResume.canGuideM1)
     }
   }
 
@@ -191,6 +203,10 @@ class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
       assert(ao2.isEmpty)
       assert(!tcs2.contains(AoCorrectCmd("ON", 1)))
       assert(!r.forceFreeze)
+      assert(!r.guideWhilePaused.canGuideM2)
+      assert(!r.guideWhilePaused.canGuideM1)
+      assert(!r.restoreOnResume.canGuideM2)
+      assert(!r.restoreOnResume.canGuideM1)
     }
   }
 
@@ -246,6 +262,10 @@ class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
       assert(ao2.contains(TestAltairEpics.Event.SfoControlCmd(LgsSfoControl.Enable)))
       assert(!tcs2.contains(AoCorrectCmd("ON", 1)))
       assert(!r.forceFreeze)
+      assert(!r.guideWhilePaused.canGuideM2)
+      assert(r.guideWhilePaused.canGuideM1)
+      assert(r.restoreOnResume.canGuideM2)
+      assert(r.restoreOnResume.canGuideM1)
     }
   }
 


### PR DESCRIPTION
Fixed a bug: Seqexec was not restoring M2 guiding after an offset for Altair LGS mode.