### PR TITLE
SEQNG-1281 Fixed problem with system configuration indicator.

### DIFF
--- a/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -210,7 +210,7 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), 1, TCS, clientId))
+        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -231,7 +231,7 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), 1, TCS, clientId))
+        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -259,7 +259,7 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>
@@ -288,7 +288,7 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>

--- a/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -210,7 +210,17 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
+        advanceOne(q,
+                   s0,
+                   seqexecEngine.configSystem(q,
+                                              seqObsId1,
+                                              Observer(""),
+                                              UserDetails("", ""),
+                                              1,
+                                              TCS,
+                                              clientId
+                   )
+        )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -231,7 +241,17 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
+        advanceOne(q,
+                   s0,
+                   seqexecEngine.configSystem(q,
+                                              seqObsId1,
+                                              Observer(""),
+                                              UserDetails("", ""),
+                                              1,
+                                              TCS,
+                                              clientId
+                   )
+        )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -259,7 +279,14 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q,
+                                         seqObsId2,
+                                         Observer(""),
+                                         UserDetails("", ""),
+                                         1,
+                                         Instrument.F2,
+                                         clientId
+              )
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>
@@ -288,7 +315,14 @@ class SeqexecEngineSpec extends AnyFlatSpec with Matchers with NonImplicitAssert
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q,
+                                         seqObsId2,
+                                         Observer(""),
+                                         UserDetails("", ""),
+                                         1,
+                                         Instrument.F2,
+                                         clientId
+              )
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>

--- a/modules/server/src/test/scala/seqexec/server/StepsViewSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/StepsViewSpec.scala
@@ -294,7 +294,7 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), 1, TCS, clientId))
+        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -315,7 +315,7 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), 1, TCS, clientId))
+        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -343,7 +343,7 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>
@@ -372,7 +372,7 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>

--- a/modules/server/src/test/scala/seqexec/server/StepsViewSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/StepsViewSpec.scala
@@ -294,7 +294,17 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
+        advanceOne(q,
+                   s0,
+                   seqexecEngine.configSystem(q,
+                                              seqObsId1,
+                                              Observer(""),
+                                              UserDetails("", ""),
+                                              1,
+                                              TCS,
+                                              clientId
+                   )
+        )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -315,7 +325,17 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
     (for {
       q  <- Queue.bounded[IO, executeEngine.EventType](10)
       sf <-
-        advanceOne(q, s0, seqexecEngine.configSystem(q, seqObsId1, Observer(""), UserDetails("", ""), 1, TCS, clientId))
+        advanceOne(q,
+                   s0,
+                   seqexecEngine.configSystem(q,
+                                              seqObsId1,
+                                              Observer(""),
+                                              UserDetails("", ""),
+                                              1,
+                                              TCS,
+                                              clientId
+                   )
+        )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId1)).getOption)) {
       case Some(s) =>
         assertResult(Some(Action.ActionState.Idle))(
@@ -343,7 +363,14 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q,
+                                         seqObsId2,
+                                         Observer(""),
+                                         UserDetails("", ""),
+                                         1,
+                                         Instrument.F2,
+                                         clientId
+              )
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>
@@ -372,7 +399,14 @@ class StepsViewSpec extends AnyFlatSpec with Matchers with NonImplicitAssertions
       sf <- advanceOne(
               q,
               s0,
-              seqexecEngine.configSystem(q, seqObsId2, Observer(""), UserDetails("", ""), 1, Instrument.F2, clientId)
+              seqexecEngine.configSystem(q,
+                                         seqObsId2,
+                                         Observer(""),
+                                         UserDetails("", ""),
+                                         1,
+                                         Instrument.F2,
+                                         clientId
+              )
             )
     } yield inside(sf.flatMap((EngineState.sequences[IO] ^|-? index(seqObsId2)).getOption)) {
       case Some(s) =>

--- a/modules/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -93,32 +93,36 @@ class SeqexecCommandRoutes[F[_]: Sync](
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "stop" / ObserverVar(
           obs
-        ) as _ =>
-      se.stopObserve(inputQueue, obsId, obs, graceful = false) *>
+        ) as user =>
+      se.stopObserve(inputQueue, obsId, obs, user, graceful = false) *>
         Ok(s"Stop requested for ${obsId.format} on step $stepId")
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "stopGracefully" / ObserverVar(
           obs
-        ) as _ =>
-      se.stopObserve(inputQueue, obsId, obs, graceful = true) *>
+        ) as user =>
+      se.stopObserve(inputQueue, obsId, obs, user, graceful = true) *>
         Ok(s"Stop gracefully requested for ${obsId.format} on step $stepId")
 
-    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "abort" / ObserverVar(obs) as _ =>
-      se.abortObserve(inputQueue, obsId, obs) *>
+    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "abort" / ObserverVar(obs) as user =>
+      se.abortObserve(inputQueue, obsId, obs, user) *>
         Ok(s"Abort requested for ${obsId.format} on step $stepId")
 
-    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "pauseObs" / ObserverVar(obs) as _ =>
-      se.pauseObserve(inputQueue, obsId, obs, graceful = false) *>
+    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "pauseObs" / ObserverVar(
+          obs
+        ) as user =>
+      se.pauseObserve(inputQueue, obsId, obs, user, graceful = false) *>
         Ok(s"Pause observation requested for ${obsId.format} on step $stepId")
 
     case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "pauseObsGracefully" / ObserverVar(
           obs
-        ) as _ =>
-      se.pauseObserve(inputQueue, obsId, obs, graceful = true) *>
+        ) as user =>
+      se.pauseObserve(inputQueue, obsId, obs, user, graceful = true) *>
         Ok(s"Pause observation gracefully requested for ${obsId.format} on step $stepId")
 
-    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "resumeObs" / ObserverVar(obs) as _ =>
-      se.resumeObserve(inputQueue, obsId, obs) *>
+    case POST -> Root / ObsIdVar(obsId) / PosIntVar(stepId) / "resumeObs" / ObserverVar(
+          obs
+        ) as user =>
+      se.resumeObserve(inputQueue, obsId, obs, user) *>
         Ok(s"Resume observation requested for ${obsId.format} on step $stepId")
 
     case POST -> Root / "operator" / OperatorVar(op) as user =>
@@ -212,7 +216,7 @@ class SeqexecCommandRoutes[F[_]: Sync](
     case POST -> Root / "execute" / ObsIdVar(oid) / PosIntVar(step) / ResourceVar(
           resource
         ) / ObserverVar(obs) / ClientIDVar(clientId) as u =>
-      se.configSystem(inputQueue, oid, obs, step, resource, clientId) *>
+      se.configSystem(inputQueue, oid, obs, u, step, resource, clientId) *>
         Ok(s"Run ${resource.show} from config at ${oid.format}/$step by ${u.username}/${obs.value}")
 
   }

--- a/modules/web/server/src/test/scala/seqexec/web/server/http4s/SeqexecCommandRoutesSpec.scala
+++ b/modules/web/server/src/test/scala/seqexec/web/server/http4s/SeqexecCommandRoutesSpec.scala
@@ -281,7 +281,7 @@ class SeqexecCommandRoutesSpec
     val engine = mock[SeqexecEngine[IO]]
     inAnyOrder {
       (engine.stopObserve _)
-        .expects(*, *, *, false)
+        .expects(*, *, *, *, false)
         .anyNumberOfTimes()
         .returning(IO.unit)
     }
@@ -308,7 +308,7 @@ class SeqexecCommandRoutesSpec
     val engine = mock[SeqexecEngine[IO]]
     inAnyOrder {
       (engine.stopObserve _)
-        .expects(*, *, *, true)
+        .expects(*, *, *, *, true)
         .anyNumberOfTimes()
         .returning(IO.unit)
     }
@@ -335,7 +335,7 @@ class SeqexecCommandRoutesSpec
     val engine = mock[SeqexecEngine[IO]]
     inAnyOrder {
       (engine.abortObserve _)
-        .expects(*, *, *)
+        .expects(*, *, *, *)
         .anyNumberOfTimes()
         .returning(IO.unit)
     }
@@ -362,7 +362,7 @@ class SeqexecCommandRoutesSpec
     val engine = mock[SeqexecEngine[IO]]
     inAnyOrder {
       (engine.pauseObserve _)
-        .expects(*, *, *, false)
+        .expects(*, *, *, *, false)
         .anyNumberOfTimes()
         .returning(IO.unit)
     }
@@ -389,7 +389,7 @@ class SeqexecCommandRoutesSpec
     val engine = mock[SeqexecEngine[IO]]
     inAnyOrder {
       (engine.pauseObserve _)
-        .expects(*, *, *, true)
+        .expects(*, *, *, *, true)
         .anyNumberOfTimes()
         .returning(IO.unit)
     }
@@ -417,7 +417,7 @@ class SeqexecCommandRoutesSpec
     val engine = mock[SeqexecEngine[IO]]
     inAnyOrder {
       (engine.resumeObserve _)
-        .expects(*, *, *)
+        .expects(*, *, *, *)
         .anyNumberOfTimes()
         .returning(IO.unit)
     }


### PR DESCRIPTION
The problem was that, in order to see the change of the observer name when commanding a system configuration, the system was forcing a sequence refresh in the client. That made the client load the new observer's name, but also reset the subsystems state.
I change the way the observer name is set when triggering other actions. Now it will generate an event to the client to refresh just the observer's name, removing the need to force a full refresh.