### PR TITLE
REL-4082 Workaround for GNIRS filter 2 problem.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -236,7 +236,11 @@ object Gnirs {
         case Filter.H_plus_ND100X  => GnirsController.Filter2Pos.H
         case Filter.H2_plus_ND100X => GnirsController.Filter2Pos.H2
         case Filter.PAH            => GnirsController.Filter2Pos.PAH
-        case _                     => GnirsController.Filter2Pos.Open
+        /* REL-4082: Workaround for Filter 2 wheel mechanical problems.
+   TODO: Revert when filter wheel is repaired.
+      case _                     => GnirsController.Filter2Pos.Open
+         */
+        case _                     => GnirsController.Filter2Pos.XD
       }
       .map(GnirsController.Manual)
       .getOrElse {


### PR DESCRIPTION
Workaround to reduce the need to move GNIRS filter wheel 2. Now we try to keep it always at position XD.