### PR TITLE
FR-72718 Fixed some bugs in target filter control.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/altair/AltairController.scala
+++ b/modules/server/src/main/scala/seqexec/server/altair/AltairController.scala
@@ -56,14 +56,13 @@ object AltairController {
   implicit val showAltairConfig: Show[AltairConfig] = Show.fromToString[AltairConfig]
 
   sealed case class AltairPauseResume[F[_]](
-    pause:              Option[F[Unit]],
-    guideWhilePaused:   GuideCapabilities,
-    pauseTargetFilter:  Boolean,
-    resume:             Option[F[Unit]],
-    restoreOnResume:    GuideCapabilities,
-    resumeTargetFilter: Boolean,
-    config:             Option[F[Unit]],
-    forceFreeze:        Boolean
+    pause:             Option[F[Unit]],
+    guideWhilePaused:  GuideCapabilities,
+    pauseTargetFilter: Boolean,
+    resume:            Option[F[Unit]],
+    restoreOnResume:   GuideCapabilities,
+    config:            Option[F[Unit]],
+    forceFreeze:       Boolean
   )
 
 }

--- a/modules/server/src/main/scala/seqexec/server/altair/AltairControllerDisabled.scala
+++ b/modules/server/src/main/scala/seqexec/server/altair/AltairControllerDisabled.scala
@@ -27,7 +27,6 @@ class AltairControllerDisabled[F[_]: Logger: Applicative] extends AltairControll
       pauseTargetFilter = false,
       overrideLogMessage("Altair", "resume AO loops").some,
       GuideCapabilities(canGuideM2 = false, canGuideM1 = false),
-      resumeTargetFilter = false,
       none,
       forceFreeze = true
     ).pure[F]

--- a/modules/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
+++ b/modules/server/src/main/scala/seqexec/server/altair/AltairControllerSim.scala
@@ -28,7 +28,6 @@ object AltairControllerSim {
         pauseTargetFilter = false,
         L.info(s"Simulate restoring Altair configuration $cfg because of $resumeReasons").some,
         GuideCapabilities(canGuideM2 = false, canGuideM1 = false),
-        resumeTargetFilter = false,
         none,
         forceFreeze = true
       ).pure[F]

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -123,11 +123,10 @@ object TcsNorthControllerEpicsAo {
           L.debug(s"Target filtering ${filterEnabled.fold("activated", "deactivated")}.")
 
       def sysConfig(
-        current:            EpicsTcsAoConfig,
-        demand:             TcsNorthAoConfig,
-        pauseTargetFilter:  Boolean,
-        resumeTargetFilter: Boolean,
-        aoConfigO:          Option[F[Unit]]
+        current:           EpicsTcsAoConfig,
+        demand:            TcsNorthAoConfig,
+        pauseTargetFilter: Boolean,
+        aoConfigO:         Option[F[Unit]]
       ): F[EpicsTcsAoConfig] = {
         val mountConfigParams   =
           commonController.configMountPos(subsystems, current, demand.tc, EpicsTcsAoConfig.base)
@@ -163,7 +162,7 @@ object TcsNorthControllerEpicsAo {
                  )
                    epicsSys.waitAGInPosition(agTimeout) *> L.debug("AG inposition")
                  else Applicative[F].unit
-            _ <- executeTargetFilterConf(true).whenA(resumeTargetFilter)
+            _ <- executeTargetFilterConf(true).whenA(pauseTargetFilter && mountMoves)
             _ <- L.debug("Completed TCS configuration")
           } yield s
         } else
@@ -199,7 +198,6 @@ object TcsNorthControllerEpicsAo {
                            s1,
                            adjustedDemand,
                            pr.pauseTargetFilter,
-                           pr.resumeTargetFilter,
                            pr.config
                          )
         _             <- guideOn(subsystems, s2, adjustedDemand, pr.restoreOnResume)


### PR DESCRIPTION
The main problem was that pausing the target filter was depending on if the ao guiding would be paused on this step or not. Which means that Seqexec was not disabling the filter if the ao was being paused in this step because it was paused in the previous one. 
Target filter must be disabled for all offsets, except for small offsets that will be applied with ao guiding enabled. 