### PR TITLE
Revert "Update commons-httpclient to 3.1"

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -34,7 +34,7 @@ object Settings {
 
     val http4sVersion  = "0.21.33"
     val squants        = "1.8.3"
-    val commonsHttp    = "3.1"
+    val commonsHttp    = "2.0.2"
     val unboundId      = "3.2.1"
     val jwt            = "5.0.0"
     val slf4j          = "2.0.3"


### PR DESCRIPTION
Reverts gemini-hlsw/seqexec#2132
This updates breaks smart gcal updates