### PR TITLE
Split keyword messages in smaller chunks.

### DIFF
--- a/modules/model/jvm/src/main/scala/seqexec/model/config/SeqexecEngineConfiguration.scala
+++ b/modules/model/jvm/src/main/scala/seqexec/model/config/SeqexecEngineConfiguration.scala
@@ -46,6 +46,8 @@ trait GhostSettings
  *   Timeout to listen for EPICS events
  * @param dhsTimeout
  *   Timeout for DHS operations
+ * @param dhsMaxSize
+ *   Limit of keywords to send in one DHS message
  */
 final case class SeqexecEngineConfiguration(
   odb:                     Uri,
@@ -63,7 +65,8 @@ final case class SeqexecEngineConfiguration(
   epicsCaAddrList:         Option[String],
   readRetries:             Int,
   ioTimeout:               FiniteDuration,
-  dhsTimeout:              FiniteDuration
+  dhsTimeout:              FiniteDuration,
+  dhsMaxSize:              Int
 )
 
 object SeqexecEngineConfiguration {
@@ -86,7 +89,8 @@ object SeqexecEngineConfiguration {
        x.epicsCaAddrList,
        x.readRetries,
        x.ioTimeout,
-       x.dhsTimeout
+       x.dhsTimeout,
+       x.dhsMaxSize
       )
     )
 

--- a/modules/server/src/main/scala/seqexec/server/FileIdProvider.scala
+++ b/modules/server/src/main/scala/seqexec/server/FileIdProvider.scala
@@ -10,8 +10,10 @@ object FileIdProvider {
 
   def fileId[F[_]](env: ObserveEnvironment[F]): F[ImageFileId] =
     // All instruments ask the DHS for an ImageFileId
-    env.dhs.createImage(
-      DhsClient.ImageParameters(DhsClient.Permanent, List(env.inst.contributorName, "dhs-http"))
-    )
+    env.dhs
+      .dhsClient("")
+      .createImage(
+        DhsClient.ImageParameters(DhsClient.Permanent, List(env.inst.contributorName, "dhs-http"))
+      )
 
 }

--- a/modules/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
+++ b/modules/server/src/main/scala/seqexec/server/ObserveEnvironment.scala
@@ -13,7 +13,7 @@ import seqexec.server.tcs.Tcs
  */
 final case class ObserveEnvironment[F[_]](
   odb:      OdbProxy[F],
-  dhs:      DhsClient[F],
+  dhs:      DhsClientProvider[F],
   config:   CleanConfig,
   stepType: StepType,
   obsId:    Observation.Id,

--- a/modules/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -784,7 +784,7 @@ object SeqTranslate {
     private val tcsNorthDisabled: TcsNorthController[F]     = new TcsNorthControllerDisabled[F]
     private val gemsDisabled: GemsController[F]             = new GemsControllerDisabled[F]
     private val altairDisabled: AltairController[F]         = new AltairControllerDisabled[F]
-    private val dhsDisabled: DhsClient[F]                   = new DhsClientDisabled[F]
+    private val dhsDisabled: DhsClientProvider[F]           = (_: String) => new DhsClientDisabled[F]
     private val gcalDisabled: GcalController[F]             = new GcalControllerDisabled[F]
     private val flamingos2Disabled: Flamingos2Controller[F] = new Flamingos2ControllerDisabled[F]
     private val gmosSouthDisabled: GmosSouthController[F]   =
@@ -814,7 +814,7 @@ object SeqTranslate {
       if (overrides.isTcsEnabled) systems.altair
       else altairDisabled
 
-    def dhs(overrides: SystemOverrides): DhsClient[F] =
+    def dhs(overrides: SystemOverrides): DhsClientProvider[F] =
       if (overrides.isDhsEnabled) systems.dhs
       else dhsDisabled
 

--- a/modules/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -4,11 +4,9 @@
 package seqexec.server.flamingos2
 
 import java.lang.{ Double => JDouble }
-
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.SECONDS
 import scala.reflect.ClassTag
-
 import cats.data.EitherT
 import cats.data.Kleisli
 import cats.effect.Sync
@@ -27,9 +25,7 @@ import seqexec.model.enum.ObserveCommandResult
 import seqexec.server.ConfigUtilOps._
 import seqexec.server._
 import seqexec.server.flamingos2.Flamingos2Controller._
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsInstrument
-import seqexec.server.keywords.KeywordsClient
+import seqexec.server.keywords.{ DhsClient, DhsClientProvider, DhsInstrument, KeywordsClient }
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.Length
 import squants.space.Arcseconds
@@ -38,8 +34,8 @@ import squants.time.Time
 import cats.effect.Async
 
 final case class Flamingos2[F[_]: Async: Logger](
-  f2Controller: Flamingos2Controller[F],
-  dhsClient:    DhsClient[F]
+  f2Controller:      Flamingos2Controller[F],
+  dhsClientProvider: DhsClientProvider[F]
 ) extends DhsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -50,6 +46,8 @@ final case class Flamingos2[F[_]: Async: Logger](
   override val contributorName: String = "flamingos2"
 
   override val dhsInstrumentName: String = "F2"
+
+  override val dhsClient: DhsClient[F] = dhsClientProvider.dhsClient(dhsInstrumentName)
 
   override val keywordsClient: KeywordsClient[F] = this
 

--- a/modules/server/src/main/scala/seqexec/server/gmos/Gmos.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/Gmos.scala
@@ -5,7 +5,6 @@ package seqexec.server.gmos
 
 import java.lang.{ Double => JDouble }
 import java.lang.{ Integer => JInt }
-
 import scala.concurrent.duration._
 import cats._
 import cats.data.EitherT
@@ -40,8 +39,7 @@ import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.Config.NSConfig
 import seqexec.server.gmos.GmosController.Config._
 import seqexec.server.gmos.GmosController.SiteDependentTypes
-import seqexec.server.keywords.DhsInstrument
-import seqexec.server.keywords.KeywordsClient
+import seqexec.server.keywords.{ DhsInstrument, KeywordsClient }
 import shapeless.tag
 import cats.effect.{ Ref, Temporal }
 import squants.Seconds

--- a/modules/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -22,16 +22,16 @@ import seqexec.server.StepType
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.NorthTypes
 import seqexec.server.gmos.GmosController.northConfigTypes
-import seqexec.server.keywords.DhsClient
+import seqexec.server.keywords.{ DhsClient, DhsClientProvider }
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.Length
 import squants.space.Arcseconds
 import cats.effect.{ Ref, Temporal }
 
 final case class GmosNorth[F[_]: Temporal: Logger] private (
-  c:         GmosNorthController[F],
-  dhsClient: DhsClient[F],
-  nsCmdR:    Ref[F, Option[NSObserveCommand]]
+  c:                 GmosNorthController[F],
+  dhsClientProvider: DhsClientProvider[F],
+  nsCmdR:            Ref[F, Option[NSObserveCommand]]
 ) extends Gmos[F, NorthTypes](
       c,
       new SiteSpecifics[NorthTypes] {
@@ -70,6 +70,7 @@ final case class GmosNorth[F[_]: Temporal: Logger] private (
     ) {
   override val resource: Instrument      = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"
+  override val dhsClient: DhsClient[F]   = dhsClientProvider.dhsClient(dhsInstrumentName)
 
 }
 
@@ -77,10 +78,10 @@ object GmosNorth {
   val name: String = INSTRUMENT_NAME_PROP
 
   def apply[F[_]: Temporal: Logger](
-    c:         GmosController[F, NorthTypes],
-    dhsClient: DhsClient[F],
-    nsCmdR:    Ref[F, Option[NSObserveCommand]]
-  ): GmosNorth[F] = new GmosNorth[F](c, dhsClient, nsCmdR)
+    c:                 GmosController[F, NorthTypes],
+    dhsClientProvider: DhsClientProvider[F],
+    nsCmdR:            Ref[F, Option[NSObserveCommand]]
+  ): GmosNorth[F] = new GmosNorth[F](c, dhsClientProvider, nsCmdR)
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.GmosN

--- a/modules/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -22,16 +22,16 @@ import seqexec.server.StepType
 import seqexec.server.gmos.Gmos.SiteSpecifics
 import seqexec.server.gmos.GmosController.SouthTypes
 import seqexec.server.gmos.GmosController.southConfigTypes
-import seqexec.server.keywords.DhsClient
+import seqexec.server.keywords.{ DhsClient, DhsClientProvider }
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.Length
 import squants.space.Arcseconds
 import cats.effect.{ Ref, Temporal }
 
 final case class GmosSouth[F[_]: Temporal: Logger] private (
-  c:         GmosSouthController[F],
-  dhsClient: DhsClient[F],
-  nsCmdR:    Ref[F, Option[NSObserveCommand]]
+  c:                 GmosSouthController[F],
+  dhsClientProvider: DhsClientProvider[F],
+  nsCmdR:            Ref[F, Option[NSObserveCommand]]
 ) extends Gmos[F, SouthTypes](
       c,
       new SiteSpecifics[SouthTypes] {
@@ -70,16 +70,17 @@ final case class GmosSouth[F[_]: Temporal: Logger] private (
     ) {
   override val resource: Instrument      = Instrument.GmosS
   override val dhsInstrumentName: String = "GMOS-S"
+  override val dhsClient: DhsClient[F]   = dhsClientProvider.dhsClient(dhsInstrumentName)
 }
 
 object GmosSouth {
   val name: String = INSTRUMENT_NAME_PROP
 
   def apply[F[_]: Temporal: Logger](
-    c:         GmosController[F, SouthTypes],
-    dhsClient: DhsClient[F],
-    nsCmdR:    Ref[F, Option[NSObserveCommand]]
-  ): GmosSouth[F] = new GmosSouth[F](c, dhsClient, nsCmdR)
+    c:                 GmosController[F, SouthTypes],
+    dhsClientProvider: DhsClientProvider[F],
+    nsCmdR:            Ref[F, Option[NSObserveCommand]]
+  ): GmosSouth[F] = new GmosSouth[F](c, dhsClientProvider, nsCmdR)
 
   object specifics extends InstrumentSpecifics {
     override val instrument: Instrument = Instrument.GmosS

--- a/modules/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -5,7 +5,6 @@ package seqexec.server.gnirs
 
 import java.lang.{ Double => JDouble }
 import java.lang.{ Integer => JInt }
-
 import cats.data.EitherT
 import cats.data.Kleisli
 import cats.effect.{ Async, Sync }
@@ -27,20 +26,20 @@ import seqexec.server.CleanConfig.extractItem
 import seqexec.server.ConfigUtilOps._
 import seqexec.server._
 import seqexec.server.gnirs.GnirsController.{ CCConfig, DCConfig, Filter1, Other, ReadMode }
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsInstrument
-import seqexec.server.keywords.KeywordsClient
+import seqexec.server.keywords.{ DhsClient, DhsClientProvider, DhsInstrument, KeywordsClient }
 import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 
 final case class Gnirs[F[_]: Logger: Async](
-  controller: GnirsController[F],
-  dhsClient:  DhsClient[F]
+  controller:        GnirsController[F],
+  dhsClientProvider: DhsClientProvider[F]
 ) extends DhsInstrument[F]
     with InstrumentSystem[F] {
   override val contributorName: String   = "ngnirsdc1"
   override val dhsInstrumentName: String = "GNIRS"
+
+  override val dhsClient: DhsClient[F] = dhsClientProvider.dhsClient(dhsInstrumentName)
 
   override val keywordsClient: KeywordsClient[F] = this
 

--- a/modules/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -5,7 +5,6 @@ package seqexec.server.gsaoi
 
 import java.lang.{ Double => JDouble }
 import java.lang.{ Integer => JInt }
-
 import cats.data.EitherT
 import cats.data.Kleisli
 import cats.effect.{ Async, Sync }
@@ -31,9 +30,7 @@ import seqexec.server.InstrumentSystem._
 import seqexec.server.Progress
 import seqexec.server.SeqexecFailure
 import seqexec.server.gsaoi.GsaoiController._
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsInstrument
-import seqexec.server.keywords.KeywordsClient
+import seqexec.server.keywords.{ DhsClient, DhsClientProvider, DhsInstrument, KeywordsClient }
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import shapeless.tag
 import squants.Length
@@ -42,8 +39,8 @@ import squants.space.Arcseconds
 import squants.time.TimeConversions._
 
 final case class Gsaoi[F[_]: Logger: Async](
-  controller: GsaoiController[F],
-  dhsClient:  DhsClient[F]
+  controller:        GsaoiController[F],
+  dhsClientProvider: DhsClientProvider[F]
 ) extends DhsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -84,6 +81,8 @@ final case class Gsaoi[F[_]: Logger: Async](
     controller.observeProgress(total)
 
   override val dhsInstrumentName: String = "GSAOI"
+
+  override val dhsClient: DhsClient[F] = dhsClientProvider.dhsClient(dhsInstrumentName)
 
   override val resource: Instrument = Instrument.Gsaoi
 

--- a/modules/server/src/main/scala/seqexec/server/keywords/DhsClientProvider.scala
+++ b/modules/server/src/main/scala/seqexec/server/keywords/DhsClientProvider.scala
@@ -1,0 +1,8 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package seqexec.server.keywords
+
+trait DhsClientProvider[F[_]] {
+  def dhsClient(instrumentName: String): DhsClient[F]
+}

--- a/modules/server/src/main/scala/seqexec/server/keywords/package.scala
+++ b/modules/server/src/main/scala/seqexec/server/keywords/package.scala
@@ -39,22 +39,19 @@ package keywords {
       dhsClient.setKeywords(id, keywords, finalFlag)
 
     def closeImage(id: ImageFileId): F[Unit] =
-      dhsClient.setKeywords(id,
-                            KeywordBag(StringKeyword(KeywordName.INSTRUMENT, dhsInstrumentName)),
-                            finalFlag = true
-      )
+      dhsClient.setKeywords(id, KeywordBag.empty, finalFlag = true)
 
-    def keywordsBundler: KeywordsBundler[F] = DhsInstrument.kb[F](dhsInstrumentName)
+    def keywordsBundler: KeywordsBundler[F] = DhsInstrument.kb[F]
 
   }
 
   object DhsInstrument {
-    def kb[F[_]: Monad](dhsInstrumentName: String): KeywordsBundler[F] = new KeywordsBundler[F] {
+    def kb[F[_]: Monad]: KeywordsBundler[F] = new KeywordsBundler[F] {
       def bundleKeywords(
         ks: List[KeywordBag => F[KeywordBag]]
       ): F[KeywordBag] = {
         val z =
-          Applicative[F].pure(KeywordBag(StringKeyword(KeywordName.INSTRUMENT, dhsInstrumentName)))
+          Applicative[F].pure(KeywordBag.empty)
         ks.foldLeft(z) { case (a, b) => a.flatMap(b) }
       }
     }

--- a/modules/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -33,9 +33,7 @@ import seqexec.server.InstrumentSystem.StopObserveCmd
 import seqexec.server.InstrumentSystem.UnpausableControl
 import seqexec.server.Progress
 import seqexec.server.SeqexecFailure
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsInstrument
-import seqexec.server.keywords.KeywordsClient
+import seqexec.server.keywords.{ DhsClient, DhsClientProvider, DhsInstrument, KeywordsClient }
 import seqexec.server.nifs.NifsController._
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import shapeless.tag
@@ -45,8 +43,8 @@ import squants.space.Arcseconds
 import squants.time.TimeConversions._
 
 final case class Nifs[F[_]: Logger: Async](
-  controller: NifsController[F],
-  dhsClient:  DhsClient[F]
+  controller:        NifsController[F],
+  dhsClientProvider: DhsClientProvider[F]
 ) extends DhsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -84,6 +82,8 @@ final case class Nifs[F[_]: Logger: Async](
     controller.observeProgress(total)
 
   override val dhsInstrumentName: String = "NIFS"
+
+  override val dhsClient: DhsClient[F] = dhsClientProvider.dhsClient(dhsInstrumentName)
 
   override val resource: Instrument = Instrument.Nifs
 

--- a/modules/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -36,9 +36,7 @@ import seqexec.server.InstrumentSystem.StopObserveCmd
 import seqexec.server.InstrumentSystem.UnpausableControl
 import seqexec.server.Progress
 import seqexec.server.SeqexecFailure
-import seqexec.server.keywords.DhsClient
-import seqexec.server.keywords.DhsInstrument
-import seqexec.server.keywords.KeywordsClient
+import seqexec.server.keywords.{ DhsClient, DhsClientProvider, DhsInstrument, KeywordsClient }
 import seqexec.server.niri.NiriController._
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.Length
@@ -48,8 +46,8 @@ import squants.time.TimeConversions._
 import cats.effect.Async
 
 final case class Niri[F[_]: Async: Logger](
-  controller: NiriController[F],
-  dhsClient:  DhsClient[F]
+  controller:        NiriController[F],
+  dhsClientProvider: DhsClientProvider[F]
 ) extends DhsInstrument[F]
     with InstrumentSystem[F] {
 
@@ -81,6 +79,8 @@ final case class Niri[F[_]: Async: Logger](
   ): fs2.Stream[F, Progress] = controller.observeProgress(total)
 
   override val dhsInstrumentName: String = "NIRI"
+
+  override val dhsClient: DhsClient[F] = dhsClientProvider.dhsClient(dhsInstrumentName)
 
   override val keywordsClient: KeywordsClient[F] = this
 

--- a/modules/web/server/src/main/resources/app.conf
+++ b/modules/web/server/src/main/resources/app.conf
@@ -75,6 +75,7 @@ seqexec-engine {
     readRetries = 1
     ioTimeout = 5 seconds
     dhsTimeout = 20 seconds
+    dhsMaxSize = 32
     gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
     gpiGDS = "http://localhost:8888/xmlrpc"
     ghostUrl = "vm://ghost?marshal=false&broker.persistent=false"

--- a/modules/web/server/src/test/scala/seqexec/web/server/config/ConfigurationLoaderSpec.scala
+++ b/modules/web/server/src/test/scala/seqexec/web/server/config/ConfigurationLoaderSpec.scala
@@ -58,7 +58,8 @@ class ConfigurationLoaderSpec extends CatsEffectSuite {
     Some("127.0.0.1"),
     0,
     5.seconds,
-    10.seconds
+    10.seconds,
+    32
   )
   val ref    = SeqexecConfiguration(Site.GS, Mode.Development, server, ws, gcal, auth)
 
@@ -149,6 +150,7 @@ seqexec-engine {
     readRetries = 0
     ioTimeout = 5 seconds
     dhsTimeout = 10 seconds
+    dhsMaxSize = 32
     gpiUrl = "vm://gpi?marshal=false&broker.persistent=false"
     gpiGDS = "http://localhost:8888/xmlrpc"
     ghostUrl = "vm://ghost?marshal=false&broker.persistent=false"


### PR DESCRIPTION
Limit the size of keyword messages for the DHS. Long list of keywords are now split into smaller chunks before sending them to the DHS.