### PR TITLE
FR-42705 Don't enable M1 guiding for GeMS on skies.

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,6 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Set up Scala
         uses: olafurpg/setup-scala@v12
         with:

--- a/modules/server/src/test/scala/seqexec/server/tcs/TcsSouthControllerEpicsAoSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TcsSouthControllerEpicsAoSpec.scala
@@ -367,7 +367,7 @@ class TcsSouthControllerEpicsAoSpec extends CatsEffectSuite {
       }
 
       assert(guideOffEvents.forall(head.contains))
-      assert(!guideOnEvents.forall(tail.contains))
+      assert(!guideOnEvents.exists(tail.contains))
     }
 
   }


### PR DESCRIPTION
GeMS opens internally opens the LGS loop on skies. Accordingly, Seqexec should not enable M1 corrections on skies, because GeMS will produce none.