### PR TITLE
FR-42704 Fixed bug in GeMS control, where Seqexec disabled guiding.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/gems/Gems.scala
+++ b/modules/server/src/main/scala/seqexec/server/gems/Gems.scala
@@ -108,6 +108,7 @@ object Gems {
       }
 
     override val stateGetter: GemsWfsState[F] = controller.stateGetter
+
   }
 
   // Ignore GaosGuideOff if it was already sent in a previous step

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsSouthControllerEpicsAo.scala
@@ -274,12 +274,13 @@ object TcsSouthControllerEpicsAo {
     ): Boolean =
       !isCurrentlyGuiding(current, baseAoCfg) && isAoGuidedStep(baseAoCfg, demand)
 
+    // Don't check cwfsx detector status, they do not work nor can we control them
     private def isAnyGemsSourceUsed(
       current: EpicsTcsAoConfig,
       demand:  TcsSouthAoConfig
-    ): Boolean = (demand.gaos.isCwfs1Used && current.cwfs1.isActive) ||
-      (demand.gaos.isCwfs2Used && current.cwfs2.isActive) ||
-      (demand.gaos.isCwfs3Used && current.cwfs3.isActive) ||
+    ): Boolean = (demand.gaos.isCwfs1Used && current.cwfs1.tracking.isActive) ||
+      (demand.gaos.isCwfs2Used && current.cwfs2.tracking.isActive) ||
+      (demand.gaos.isCwfs3Used && current.cwfs3.tracking.isActive) ||
       (demand.gaos.isOdgw1Used && current.odgw1.isActive) ||
       (demand.gaos.isOdgw2Used && current.odgw2.isActive) ||
       (demand.gaos.isOdgw3Used && current.odgw3.isActive) ||

--- a/modules/server/src/test/scala/seqexec/server/gems/GemsControllerEpicsSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/gems/GemsControllerEpicsSpec.scala
@@ -20,7 +20,6 @@ import seqexec.server.gems.GemsController.{
   Odgw4Usage,
   P1Usage
 }
-import seqexec.server.gems.GemsControllerEpicsSpec.DummyGsaoiGuider
 import seqexec.server.gems.TestGemsEpics.LoopEvent
 import seqexec.server.gsaoi.GsaoiGuider
 import seqexec.server.tcs.Gaos
@@ -30,15 +29,9 @@ import shapeless.tag
 import squants.space.LengthConversions._
 
 class GemsControllerEpicsSpec extends CatsEffectSuite {
+  import GemsControllerEpicsSpec._
 
   private implicit def unsafeLogger: Logger[IO] = NoOpLogger.impl[IO]
-
-  val guidingState = TestGemsEpics.defaultState.copy(
-    aniLoop = LoopState.CLOSED,
-    ttLoop = LoopState.CLOSED,
-    flexureLoop = LoopState.CLOSED,
-    focusLoop = LoopState.CLOSED
-  )
 
   val guidingConfig = GemsController.GemsOn(
     Cwfs1Usage.Use,
@@ -59,7 +52,7 @@ class GemsControllerEpicsSpec extends CatsEffectSuite {
     FocalPlaneOffset(tag[OffsetX](3.0.millimeters), tag[OffsetY](-3.0.millimeters))
 
   test("GemsControlerEpics should do nothing if there is no change in configuration") {
-    val gemsEpicsF = TestGemsEpics.build[IO](guidingState)
+    val gemsEpicsF = TestGemsEpics.build[IO](guidingStateAllEnabled)
 
     for {
       ge <- gemsEpicsF
@@ -78,7 +71,7 @@ class GemsControllerEpicsSpec extends CatsEffectSuite {
   }
 
   test("GemsControlerEpics should pause and resume guiding on offsets") {
-    val gemsEpicsF = TestGemsEpics.build[IO](guidingState)
+    val gemsEpicsF = TestGemsEpics.build[IO](guidingStateAllEnabled)
 
     for {
       ge <- gemsEpicsF
@@ -105,7 +98,7 @@ class GemsControllerEpicsSpec extends CatsEffectSuite {
   }
 
   test("GemsControlerEpics should pause guiding on a sky") {
-    val gemsEpicsF = TestGemsEpics.build[IO](guidingState)
+    val gemsEpicsF = TestGemsEpics.build[IO](guidingStateAllEnabled)
 
     for {
       ge <- gemsEpicsF
@@ -170,7 +163,7 @@ class GemsControllerEpicsSpec extends CatsEffectSuite {
   }
 
   test("GemsControlerEpics should properly handle offset to unguided position") {
-    val gemsEpicsF = TestGemsEpics.build[IO](guidingState)
+    val gemsEpicsF = TestGemsEpics.build[IO](guidingStateAllEnabled)
 
     for {
       ge <- gemsEpicsF
@@ -217,4 +210,12 @@ object GemsControllerEpicsSpec {
 
     override def endGuide: IO[Unit] = IO.unit
   }
+
+  val guidingStateAllEnabled = TestGemsEpics.defaultState.copy(
+    aniLoop = LoopState.CLOSED,
+    ttLoop = LoopState.CLOSED,
+    flexureLoop = LoopState.CLOSED,
+    focusLoop = LoopState.CLOSED
+  )
+
 }

--- a/modules/server/src/test/scala/seqexec/server/gems/TestGemsEpics.scala
+++ b/modules/server/src/test/scala/seqexec/server/gems/TestGemsEpics.scala
@@ -171,11 +171,12 @@ case class TestGemsEpics[F[_]: Async](
 
   override def sourceMask: F[Int] = state.get.map(State.sourceMask.get)
 
-  override def apd1Active: F[Boolean] = state.get.map(State.apd1Active.get)
+  // The apd statuses do not work in the real system.
+  override def apd1Active: F[Boolean] = false.pure[F]
 
-  override def apd2Active: F[Boolean] = state.get.map(State.apd2Active.get)
+  override def apd2Active: F[Boolean] = false.pure[F]
 
-  override def apd3Active: F[Boolean] = state.get.map(State.apd3Active.get)
+  override def apd3Active: F[Boolean] = false.pure[F]
 
   override def scienceAdcLoopActive: F[Boolean] = state.get.map(State.scienceAdcLoopActive.get)
 


### PR DESCRIPTION
The main issue was that some logic depended on reading the statuses of c1, c2 and c3, but in RTC2 they don't work.
Also, fixed some unit tests.