### PR TITLE
Fixed retrieval of GeMS probes state when parked.

### DIFF
--- a/modules/server/src/test/scala/seqexec/server/tcs/TcsSouthControllerEpicsAoSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TcsSouthControllerEpicsAoSpec.scala
@@ -104,10 +104,10 @@ class TcsSouthControllerEpicsAoSpec extends CatsEffectSuite {
         tag[CWFS3Config](
           GuiderConfig(ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn)
         ),
-        tag[ODGW1Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)),
-        tag[ODGW2Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)),
-        tag[ODGW3Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)),
-        tag[ODGW4Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff))
+        tag[ODGW1Config](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff)),
+        tag[ODGW2Config](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff)),
+        tag[ODGW3Config](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff)),
+        tag[ODGW4Config](GuiderConfig(ProbeTrackingConfig.Parked, GuiderSensorOff))
       ),
       tag[OIConfig](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff))
     ),


### PR DESCRIPTION
This problem was like the parallel of the one where Seqexec did not parked GeMS probes if they were not defined in the TCS mapping, but now it was that Seqexec did not recognize they were parked if not defined in the TCS mapping. Which they never were, because they were parked. This caused Seqexec to send the park command on each step. Not a critical problem, but it made it waste ~5 seconds per step.