### PR TITLE
Update to Cats Effect 3.5 and friends

### DIFF
--- a/modules/web/server/src/main/scala/scala/web/server/common/StaticRoutes.scala
+++ b/modules/web/server/src/main/scala/scala/web/server/common/StaticRoutes.scala
@@ -9,6 +9,7 @@ import cats.data.OptionT
 import cats.effect.Sync
 import cats.instances.string._
 import cats.syntax.eq._
+import fs2.compression.Compression
 import org.http4s.CacheDirective._
 import org.http4s.HttpRoutes
 import org.http4s.Request
@@ -17,7 +18,7 @@ import org.http4s.StaticFile
 import org.http4s.headers.`Cache-Control`
 import org.http4s.server.middleware.GZip
 
-class StaticRoutes[F[_]: Sync](
+class StaticRoutes[F[_]: Sync: Compression](
   devMode:       Boolean,
   builtAtMillis: Long
 ) {

--- a/modules/web/server/src/main/scala/seqexec/web/server/http4s/GuideConfigDbRoutes.scala
+++ b/modules/web/server/src/main/scala/seqexec/web/server/http4s/GuideConfigDbRoutes.scala
@@ -5,6 +5,7 @@ package seqexec.web.server.http4s
 
 import cats.effect.Async
 import cats.syntax.all._
+import fs2.compression.Compression
 import org.typelevel.log4cats.Logger
 import org.http4s.EntityDecoder
 import org.http4s.HttpRoutes
@@ -15,7 +16,8 @@ import seqexec.server.tcs.GuideConfig
 import seqexec.server.tcs.GuideConfigDb
 import seqexec.server.tcs.GuideConfigDb._
 
-class GuideConfigDbRoutes[F[_]: Async: Logger](db: GuideConfigDb[F]) extends Http4sDsl[F] {
+class GuideConfigDbRoutes[F[_]: Async: Logger: Compression](db: GuideConfigDb[F])
+    extends Http4sDsl[F] {
 
   implicit val decoder: EntityDecoder[F, GuideConfig] = jsonOf
 

--- a/modules/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
+++ b/modules/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecCommandRoutes.scala
@@ -5,6 +5,7 @@ package seqexec.web.server.http4s
 
 import cats.effect.Async
 import cats.syntax.all._
+import fs2.compression.Compression
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.server.middleware.GZip
@@ -22,7 +23,7 @@ import seqexec.web.server.security.TokenRefresher
 /**
  * Rest Endpoints under the /api route
  */
-class SeqexecCommandRoutes[F[_]: Async](
+class SeqexecCommandRoutes[F[_]: Async: Compression](
   auth:       AuthenticationService[F],
   inputQueue: server.EventQueue[F],
   se:         SeqexecEngine[F]

--- a/modules/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
+++ b/modules/web/server/src/main/scala/seqexec/web/server/http4s/SeqexecUIApiRoutes.scala
@@ -12,8 +12,10 @@ import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.effect.Sync
 import cats.syntax.all._
+import com.comcast.ip4s.Dns
 import fs2.Pipe
 import fs2.Stream
+import fs2.compression.Compression
 import fs2.concurrent.Topic
 import giapi.client.GiapiStatusDb
 import giapi.client.StatusValue
@@ -49,7 +51,7 @@ import seqexec.web.server.security.TokenRefresher
 /**
  * Rest Endpoints under the /api route
  */
-class SeqexecUIApiRoutes[F[_]: Async](
+class SeqexecUIApiRoutes[F[_]: Async: Compression: Dns](
   site:             Site,
   mode:             Mode,
   auth:             AuthenticationService[F],

--- a/modules/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -14,9 +14,11 @@ import scala.concurrent.duration._
 import cats.effect._
 import cats.effect.syntax.all._
 import cats.syntax.all._
+import com.comcast.ip4s.Dns
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.Appender
 import fs2.Stream
+import fs2.compression.Compression
 import cats.effect.std.{ Dispatcher, Queue }
 import fs2.concurrent.Topic
 import org.typelevel.log4cats.Logger
@@ -112,7 +114,7 @@ object WebServerLauncher extends IOApp with LogInitialization {
   }
 
   /** Resource that yields the running web server */
-  def webServer[F[_]: Logger: Async](
+  def webServer[F[_]: Logger: Async: Dns: Compression](
     conf:      SeqexecConfiguration,
     cal:       SmartGcal,
     as:        AuthenticationService[F],
@@ -168,7 +170,7 @@ object WebServerLauncher extends IOApp with LogInitialization {
 
   }
 
-  def redirectWebServer[F[_]: Logger: Async](
+  def redirectWebServer[F[_]: Logger: Async: Compression](
     gcdb: GuideConfigDb[F],
     cal:  SmartGcal
   )(conf: WebServerConfiguration): Resource[F, Server] = {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,18 +23,18 @@ object Settings {
     val scalaJSReactSortable    = "0.5.2"
 
     // Scala libraries
-    val catsEffectVersion   = "3.4.11"
+    val catsEffectVersion   = "3.5.1"
     val catsVersion         = "2.9.0"
     val mouseVersion        = "1.2.1"
-    val fs2Version          = "3.6.1"
+    val fs2Version          = "3.7.0"
     val shapelessVersion    = "2.3.9"
     val scalaParsersVersion = "1.1.2"
     val scalaXmlVersion     = "1.2.0"
     val catsTime            = "0.4.0"
 
-    val http4sVersion                  = "0.23.18"
-    val http4sBlazeVersion             = "0.23.14"
-    val http4sJdkHttpClientVersion     = "0.9.0"
+    val http4sVersion                  = "0.23.23"
+    val http4sBlazeVersion             = "0.23.15"
+    val http4sJdkHttpClientVersion     = "0.9.1"
     val http4sBoopickleVersion         = "0.23.11"
     val http4sPrometheusMetricsVersion = "0.24.3"
     val http4sScalaXmlVersion          = "0.23.13"


### PR DESCRIPTION
Because of the cancelation changes in Cats Effect 3.5.x, we must upgrade it together with FS2, http4s, Blaze, and the JDK HTTP client which include critical bug fixes. Updating Cats Effect by itself without upgrading the other libraries is known to cause issues.