### PR TITLE
Defocus support for GHOST

### DIFF
--- a/modules/server/src/main/resources/Tcs.xml
+++ b/modules/server/src/main/resources/Tcs.xml
@@ -167,6 +167,14 @@
             <record>aoFlatten</record>
             <description>Flatten AO light path</description>
         </command>
+        <command name="instrumentDefocus">
+            <description>Instrument defocus</description>
+            <parameter name="dtelFocus">
+                <channel>dtelFocus.B</channel>
+                <type>DOUBLE</type>
+                <description>Defocus offset B in mm</description>
+            </parameter>
+        </command>
         <command name="aoFollow">
             <description>GAOS probe following</description>
             <parameter name="followState">
@@ -968,6 +976,11 @@
     </Status>
     <Status name="tcsstate">
         <top>tcs</top>
+        <attribute name="dtelFocusB">
+            <channel>sad:dtelFocus.B</channel>
+            <type>DOUBLE</type>
+            <description>Instrument defocus</description>
+        </attribute>
         <attribute name="crfollow">
             <channel>crFollow.VAL</channel>
             <type>INTEGER</type>

--- a/modules/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
+++ b/modules/server/src/main/scala/seqexec/server/InstrumentSpecifics.scala
@@ -5,12 +5,17 @@ package seqexec.server
 
 import lucuma.core.enums.LightSinkName
 import squants.Length
+import scala.annotation.nowarn
 
 trait InstrumentSpecifics extends InstrumentGuide {
   def calcStepType(config: CleanConfig, isNightSeq: Boolean): Either[SeqexecFailure, StepType] =
     SequenceConfiguration.calcStepType(config, isNightSeq)
 
   override val oiOffsetGuideThreshold: Option[Length] = None
+
+  @nowarn
+  // An instrument can request an extra defocus term based on the configuration
+  def defocusB(config: CleanConfig): Option[Length] = None
 
   // The name used for this instrument in the science fold configuration
   def sfName(config: CleanConfig): LightSinkName

--- a/modules/server/src/main/scala/seqexec/server/SeqTranslate.scala
+++ b/modules/server/src/main/scala/seqexec/server/SeqTranslate.scala
@@ -469,7 +469,8 @@ object SeqTranslate {
                     )(
                       config,
                       LightPath(lsource, inst.sfName(config)),
-                      w
+                      w,
+                      inst.defocusB(config)
                     ): System[F]
                 )
             else
@@ -482,7 +483,8 @@ object SeqTranslate {
                 )(
                   config,
                   LightPath(lsource, inst.sfName(config)),
-                  w
+                  w,
+                  inst.defocusB(config)
                 ): System[F]
               }.pure[F]
 
@@ -496,7 +498,8 @@ object SeqTranslate {
               )(
                 config,
                 LightPath(lsource, inst.sfName(config)),
-                w
+                w,
+                inst.defocusB(config)
               ): System[F]
             }.pure[F]
             else
@@ -509,7 +512,8 @@ object SeqTranslate {
                 )(
                   config,
                   LightPath(lsource, inst.sfName(config)),
-                  w
+                  w,
+                  inst.defocusB(config)
                 ): System[F]
               }.pure[F]
         }
@@ -524,7 +528,8 @@ object SeqTranslate {
       def adaptGcal(b: GcalController[F] => Gcal[F])(ov: SystemOverrides): Gcal[F] = b(
         overriddenSystems.gcal(ov)
       )
-      def defaultGcal: SystemOverrides => Gcal[F]                                  = adaptGcal(Gcal.defaultGcal)
+
+      def defaultGcal: SystemOverrides => Gcal[F] = adaptGcal(Gcal.defaultGcal)
 
       stepType match {
         case StepType.CelestialObject(inst) =>

--- a/modules/server/src/main/scala/seqexec/server/tcs/BasicEpicsTcsConfig.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/BasicEpicsTcsConfig.scala
@@ -8,6 +8,7 @@ import monocle.macros.Lenses
 import seqexec.model.TelescopeGuideConfig
 import seqexec.server.tcs.TcsController._
 import squants.Angle
+import squants.space.Length
 
 final case class InstrumentPorts(
   flamingos2Port: Int,
@@ -25,6 +26,7 @@ final case class BaseEpicsTcsConfig(
   iaa:                  Angle,
   offset:               FocalPlaneOffset,
   wavelA:               Wavelength,
+  defocusB:             Length,
   pwfs1:                GuiderConfig,
   pwfs2:                GuiderConfig,
   oiwfs:                GuiderConfig,

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsConfigRetriever.scala
@@ -102,6 +102,8 @@ object TcsConfigRetriever {
 
     private def decodeNodChopOption(s: Int): Boolean = s =!= 0
 
+    private def getDefocusB: F[Length] = epicsSys.defocusB.map(Millimeters(_))
+
     private def getNodChopTrackingConfig(
       g: TcsEpics.ProbeGuideConfig[F]
     ): F[NodChopTrackingConfig] =
@@ -327,6 +329,7 @@ object TcsConfigRetriever {
         offX   <- getOffsetX
         offY   <- getOffsetY
         wl     <- getWavelength
+        df     <- getDefocusB
         p1     <- getPwfs1
         p2     <- getPwfs2
         oi     <- getOiwfs
@@ -341,6 +344,7 @@ object TcsConfigRetriever {
         iaa,
         FocalPlaneOffset(tag[OffsetX](offX), tag[OffsetY](offY)),
         wl,
+        df,
         p1,
         p2,
         oi,

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsController.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsController.scala
@@ -264,8 +264,9 @@ object TcsController {
 
   @Lenses
   final case class TelescopeConfig(
-    offsetA: Option[InstrumentOffset],
-    wavelA:  Option[Wavelength]
+    offsetA:  Option[InstrumentOffset],
+    wavelA:   Option[Wavelength],
+    defocusB: Option[Length]
   )
 
   implicit val wavelengthEq: Eq[Wavelength] = Eq.by(_.length.value)

--- a/modules/server/src/test/scala/seqexec/server/ghost/GhostArbitraries.scala
+++ b/modules/server/src/test/scala/seqexec/server/ghost/GhostArbitraries.scala
@@ -122,7 +122,7 @@ trait GhostArbitraries extends ArbTime {
     )
 
   implicit val ghostSRDualTargetConfigCogen: Cogen[StandardResolutionMode.DualTarget] =
-    Cogen[(Option[Coordinates], String, Coordinates, String, Coordinates)]
+    Cogen[(Option[Coordinates], String, Coordinates, String, Option[Coordinates])]
       .contramap(x =>
         (x.baseCoords, x.ifu1TargetName, x.ifu1Coordinates, x.ifu2TargetName, x.ifu2Coordinates)
       )
@@ -161,7 +161,7 @@ trait GhostArbitraries extends ArbTime {
     )
 
   implicit val ghostSRTargetSkyConfigCogen: Cogen[StandardResolutionMode.TargetPlusSky] =
-    Cogen[(Option[Coordinates], String, Coordinates, Coordinates)]
+    Cogen[(Option[Coordinates], String, Coordinates, Option[Coordinates])]
       .contramap(x => (x.baseCoords, x.ifu1TargetName, x.ifu1Coordinates, x.ifu2Coordinates))
 
   implicit val ghostSRSkyTargetConfigGen: Gen[StandardResolutionMode.SkyPlusTarget] =
@@ -198,7 +198,7 @@ trait GhostArbitraries extends ArbTime {
     )
 
   implicit val ghostSRSkyTargetConfigCogen: Cogen[StandardResolutionMode.SkyPlusTarget] =
-    Cogen[(Option[Coordinates], Coordinates, String, Coordinates)]
+    Cogen[(Option[Coordinates], Coordinates, String, Option[Coordinates])]
       .contramap(x => (x.baseCoords, x.ifu1Coordinates, x.ifu2TargetName, x.ifu2Coordinates))
 
   implicit val ghostHRTargetPlusSkyConfigGen: Gen[HighResolutionMode.TargetPlusSky] =
@@ -235,7 +235,7 @@ trait GhostArbitraries extends ArbTime {
     )
 
   implicit val ghostHRTargetSkyConfigCogen: Cogen[HighResolutionMode.TargetPlusSky] =
-    Cogen[(Option[Coordinates], String, Coordinates, Coordinates)]
+    Cogen[(Option[Coordinates], String, Coordinates, Option[Coordinates])]
       .contramap(x => (x.baseCoords, x.ifu1TargetName, x.ifu1Coordinates, x.ifu2Coordinates))
 
   implicit val ghostConfigArb: Arbitrary[GhostConfig] = Arbitrary {
@@ -300,7 +300,7 @@ trait GhostArbitraries extends ArbTime {
     }
 
     def extractHRIFU2Coordinates(x: GhostConfig): Option[Coordinates] = x match {
-      case c: HighResolutionMode.TargetPlusSky => Some(c.ifu2Coordinates)
+      case c: HighResolutionMode.TargetPlusSky => c.ifu2Coordinates
       case _                                   => None
     }
   }

--- a/modules/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsCommonSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TcsControllerEpicsCommonSpec.scala
@@ -59,6 +59,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
     Arcseconds(33.8),
     FocalPlaneOffset(tag[OffsetX](Millimeters(0.0)), tag[OffsetY](Millimeters(0.0))),
     Wavelength(Microns(400)),
+    Millimeters(0.0),
     GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
     GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
     GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff),
@@ -88,7 +89,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
                          M1GuideConfig.M1GuideOff,
                          M2GuideConfig.M2GuideOff
     ),
-    TelescopeConfig(None, None),
+    TelescopeConfig(None, None, None),
     BasicGuidersConfig(
       tag[P1Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)),
       tag[P2Config](GuiderConfig(ProbeTrackingConfig.Off, GuiderSensorOff)),
@@ -895,7 +896,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
     )
 
     val config = baseConfig.copy(
-      tc = TelescopeConfig(offsetDemand.some, wavelength.some)
+      tc = TelescopeConfig(offsetDemand.some, wavelength.some, none)
     )
 
     val genOut: IO[List[TestTcsEpics.TestTcsEvent]] = for {
@@ -935,7 +936,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
     )
 
     val config = baseConfig.copy(
-      tc = TelescopeConfig(offset.some, wavelength.some)
+      tc = TelescopeConfig(offset.some, wavelength.some, none)
     )
 
     val genOut: IO[List[TestTcsEpics.TestTcsEvent]] = for {
@@ -969,7 +970,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
     )
 
     val config = baseConfig.copy(
-      tc = TelescopeConfig(None, wavelengthDemand.some)
+      tc = TelescopeConfig(None, wavelengthDemand.some, None)
     )
 
     val genOut: IO[List[TestTcsEpics.TestTcsEvent]] = for {
@@ -1002,7 +1003,7 @@ class TcsControllerEpicsCommonSpec extends AnyFlatSpec with PrivateMethodTester 
     )
 
     val config = baseConfig.copy(
-      tc = TelescopeConfig(None, wavelength.some)
+      tc = TelescopeConfig(None, wavelength.some, None)
     )
 
     val genOut: IO[List[TestTcsEpics.TestTcsEvent]] = for {

--- a/modules/server/src/test/scala/seqexec/server/tcs/TcsSouthControllerEpicsAoSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TcsSouthControllerEpicsAoSpec.scala
@@ -89,7 +89,7 @@ class TcsSouthControllerEpicsAoSpec extends CatsEffectSuite {
                          M1GuideConfig.M1GuideOff,
                          M2GuideConfig.M2GuideOff
     ),
-    TelescopeConfig(None, None),
+    TelescopeConfig(None, None, None),
     AoGuidersConfig(
       tag[P1Config](
         GuiderConfig(ProbeTrackingConfig.On(NodChopTrackingConfig.Normal), GuiderSensorOn)

--- a/modules/server/src/test/scala/seqexec/server/tcs/TestTcsEpics.scala
+++ b/modules/server/src/test/scala/seqexec/server/tcs/TestTcsEpics.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit.SECONDS
 import java.time.Duration
 import scala.concurrent.duration.FiniteDuration
 import cats.effect.{ Ref, Temporal }
+import squants.space.Length
 
 case class TestTcsEpics[F[_]: Async](
   state: Ref[F, TestTcsEpics.State],
@@ -305,6 +306,11 @@ case class TestTcsEpics[F[_]: Async](
 
   override val endObserve: EpicsCommand[F] = new DummyCmd[F]
 
+  override val instrumentDefocusCmd: InstrumentDefocusCmd[F] =
+    new DummyCmd[F] with InstrumentDefocusCmd[F] {
+      def setDefocus(v: Length): F[Unit] = Applicative[F].unit
+    }
+
   override val aoCorrect: AoCorrect[F] =
     new TestEpicsCommand2[F, State, TestTcsEvent, String, Int](State.aoCorrectCmd, state, out)
       with AoCorrect[F] {
@@ -444,6 +450,8 @@ case class TestTcsEpics[F[_]: Async](
   override def instrAA: F[Double] = state.get.map(_.instrAA)
 
   override def inPosition: F[String] = state.get.map(_.inPosition)
+
+  override def defocusB: F[Double] = state.get.map(_.defocusB)
 
   override def agInPosition: F[Double] = state.get.map(_.agInPosition)
 
@@ -967,6 +975,7 @@ object TestTcsEpics {
     g4GuideConfig:             ProbeGuideConfigVals,
     aoCorrect:                 String,
     aoGains:                   Int,
+    defocusB:                  Double,
     m1GuideCmd:                TestEpicsCommand1.State[String],
     m2GuideCmd:                TestEpicsCommand1.State[String],
     m2GuideModeCmd:            TestEpicsCommand1.State[String],
@@ -1341,6 +1350,7 @@ object TestTcsEpics {
     g4GuideConfig = ProbeGuideConfigVals.default,
     aoCorrect = "Off",
     aoGains = 0,
+    defocusB = 0.0,
     m1GuideCmd = TestEpicsCommand1.State[String](mark = false, ""),
     m2GuideCmd = TestEpicsCommand1.State[String](mark = false, ""),
     m2GuideModeCmd = TestEpicsCommand1.State[String](mark = false, ""),


### PR DESCRIPTION
This PR adds support to set the extra defocus term for GHOST when configuring the TCS.

* The amount to defocus is calculated from the coordinate values (eventually we'll move the calculation back to the OT)
* Then it is written to the tcs apply on the channel `$top:dtelFocus.B`
* Prior to write the value it is compared with the current value at `$top:sad:dtelFocus.B`

This is subject to testing