### PR TITLE
Add endObserve event

### DIFF
--- a/modules/engine/src/main/scala/seqexec/engine/Action.scala
+++ b/modules/engine/src/main/scala/seqexec/engine/Action.scala
@@ -15,10 +15,11 @@ import seqexec.model.enum.ActionStatus
 
 @Lenses
 final case class Action[F[_]](
-  kind:  ActionType,
-  gen:   Stream[F, Result[F]],
-  state: Action.State[F]
-)
+  kind:            ActionType,
+  gen:             Stream[F, Result[F]],
+  state:           Action.State[F],
+  uninterruptible: Boolean = false
+) { def makeUninterruptible: Action[F] = this.copy(uninterruptible = true) }
 
 object Action {
 

--- a/modules/engine/src/main/scala/seqexec/engine/Engine.scala
+++ b/modules/engine/src/main/scala/seqexec/engine/Engine.scala
@@ -162,7 +162,10 @@ class Engine[F[_]: MonadError[*[_], Throwable]: Logger, S, U](stateL: Engine.Sta
               putS(id)(qs) *> send(finished(id))
             // Execution completed
             case Some(qs)                          =>
-              putS(id)(qs) *> switch(id)(SequenceState.Idle)
+              putS(id)(qs) *> (
+                if (qs.current.execution.exists(_.uninterruptible)) send(executing(id))
+                else switch(id)(SequenceState.Idle)
+              )
           }
         } else if (Sequence.State.isRunning(seq)) {
           seq.next match {
@@ -174,7 +177,10 @@ class Engine[F[_]: MonadError[*[_], Throwable]: Logger, S, U](stateL: Engine.Sta
               putS(id)(qs) *> send(finished(id))
             // Execution completed. Check breakpoint here
             case Some(qs)                          =>
-              putS(id)(qs) *> (if (qs.getCurrentBreakpoint) {
+              putS(id)(qs) *> (if (
+                                 qs.getCurrentBreakpoint && !qs.current.execution
+                                   .exists(_.uninterruptible)
+                               ) {
                                  switch(id)(SequenceState.Idle) *> send(breakpointReached(id))
                                } else send(executing(id)))
           }

--- a/modules/engine/src/test/scala/seqexec/engine/StepSpec.scala
+++ b/modules/engine/src/test/scala/seqexec/engine/StepSpec.scala
@@ -667,7 +667,7 @@ class StepSpec extends CatsEffectSuite {
       inside(x.drop(1).headOption.flatMap(_.sequences.get(seqId))) {
         case Some(Sequence.State.Zipper(zipper, status, _)) =>
           inside(zipper.focus.focus.execution.headOption) {
-            case Some(Action(_, _, Action.State(Action.ActionState.Started, v :: _))) =>
+            case Some(Action(_, _, Action.State(Action.ActionState.Started, v :: _), _)) =>
               assertEquals(v, PartialValDouble(0.5))
           }
           assert(status.isRunning)

--- a/modules/server/src/main/scala/seqexec/server/InstrumentSystem.scala
+++ b/modules/server/src/main/scala/seqexec/server/InstrumentSystem.scala
@@ -22,6 +22,8 @@ trait InstrumentSystem[F[_]] extends System[F] {
 
   def observe(config: CleanConfig): Kleisli[F, ImageFileId, ObserveCommandResult]
 
+  def sequenceComplete: F[Unit]
+
   // Expected total observe lapse, used to calculate timeout
   def calcObserveTime(config: CleanConfig): F[Time]
 

--- a/modules/server/src/main/scala/seqexec/server/SequenceGen.scala
+++ b/modules/server/src/main/scala/seqexec/server/SequenceGen.scala
@@ -86,7 +86,7 @@ object SequenceGen {
     ): List[ParallelActions[F]] = {
       val postActions =
         this.endObserveAction.fold(post(ctx, overrides))(a =>
-          post(ctx, overrides) :+ NonEmptyList.one(a(overrides))
+          post(ctx, overrides) :+ NonEmptyList.one(a(overrides).makeUninterruptible)
         )
       NonEmptyList.fromList(configs.values.toList.map(_(overrides))).toList ++
         postActions

--- a/modules/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
+++ b/modules/server/src/main/scala/seqexec/server/flamingos2/Flamingos2.scala
@@ -7,10 +7,12 @@ import java.lang.{ Double => JDouble }
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.SECONDS
 import scala.reflect.ClassTag
+import cats.Applicative
 import cats.data.EitherT
 import cats.data.Kleisli
 import cats.effect.Sync
 import cats.syntax.all._
+import cats.effect.Async
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Reads
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
 import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
@@ -31,7 +33,6 @@ import squants.Length
 import squants.space.Arcseconds
 import squants.time.Seconds
 import squants.time.Time
-import cats.effect.Async
 
 final case class Flamingos2[F[_]: Async: Logger](
   f2Controller:      Flamingos2Controller[F],
@@ -50,6 +51,8 @@ final case class Flamingos2[F[_]: Async: Logger](
   override val dhsClient: DhsClient[F] = dhsClientProvider.dhsClient(dhsInstrumentName)
 
   override val keywordsClient: KeywordsClient[F] = this
+
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 
   override def observeControl(config: CleanConfig): InstrumentSystem.ObserveControl[F] =
     InstrumentSystem.Uncontrollable

--- a/modules/server/src/main/scala/seqexec/server/ghost/Ghost.scala
+++ b/modules/server/src/main/scala/seqexec/server/ghost/Ghost.scala
@@ -3,6 +3,7 @@
 
 package seqexec.server.ghost
 
+import cats.Applicative
 import cats.data.EitherT
 import cats.data.Kleisli
 import cats.effect.Sync
@@ -82,6 +83,8 @@ final case class Ghost[F[_]: Logger: Async](
           .as(ObserveCommandResult.Success: ObserveCommandResult)
       }
     }
+
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 
   override def configure(config: CleanConfig): F[ConfigResult[F]] =
     for {

--- a/modules/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/GmosNorth.scala
@@ -3,6 +3,8 @@
 
 package seqexec.server.gmos
 
+import cats.Applicative
+import cats.effect.{ Ref, Temporal }
 import cats.syntax.all._
 import edu.gemini.spModel.gemini.gmos.GmosNorthType
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
@@ -26,7 +28,6 @@ import seqexec.server.keywords.{ DhsClient, DhsClientProvider }
 import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.Length
 import squants.space.Arcseconds
-import cats.effect.{ Ref, Temporal }
 
 final case class GmosNorth[F[_]: Temporal: Logger] private (
   c:                 GmosNorthController[F],
@@ -71,6 +72,7 @@ final case class GmosNorth[F[_]: Temporal: Logger] private (
   override val resource: Instrument      = Instrument.GmosN
   override val dhsInstrumentName: String = "GMOS-N"
   override val dhsClient: DhsClient[F]   = dhsClientProvider.dhsClient(dhsInstrumentName)
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 
 }
 

--- a/modules/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
+++ b/modules/server/src/main/scala/seqexec/server/gmos/GmosSouth.scala
@@ -27,6 +27,7 @@ import seqexec.server.tcs.FOCAL_PLANE_SCALE
 import squants.Length
 import squants.space.Arcseconds
 import cats.effect.{ Ref, Temporal }
+import cats.Applicative
 
 final case class GmosSouth[F[_]: Temporal: Logger] private (
   c:                 GmosSouthController[F],
@@ -71,6 +72,7 @@ final case class GmosSouth[F[_]: Temporal: Logger] private (
   override val resource: Instrument      = Instrument.GmosS
   override val dhsInstrumentName: String = "GMOS-S"
   override val dhsClient: DhsClient[F]   = dhsClientProvider.dhsClient(dhsInstrumentName)
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 }
 
 object GmosSouth {

--- a/modules/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
+++ b/modules/server/src/main/scala/seqexec/server/gnirs/Gnirs.scala
@@ -30,6 +30,7 @@ import seqexec.server.keywords.{ DhsClient, DhsClientProvider, DhsInstrument, Ke
 import squants.Time
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
+import cats.Applicative
 
 final case class Gnirs[F[_]: Logger: Async](
   controller:        GnirsController[F],
@@ -57,6 +58,8 @@ final case class Gnirs[F[_]: Logger: Async](
         controller.observe(fileId, x)
       }
     }
+
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 
   override def calcObserveTime(config: CleanConfig): F[Time] =
     getDCConfig(config)

--- a/modules/server/src/main/scala/seqexec/server/gpi/Gpi.scala
+++ b/modules/server/src/main/scala/seqexec/server/gpi/Gpi.scala
@@ -67,6 +67,8 @@ final case class Gpi[F[_]: Temporal: Logger](controller: GpiController[F])
       }
     }
 
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
+
   override def configure(config: CleanConfig): F[ConfigResult[F]] =
     if (Gpi.isAlignAndCalib(config)) {
       controller.alignAndCalib.as(ConfigResult(this))

--- a/modules/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
+++ b/modules/server/src/main/scala/seqexec/server/gsaoi/Gsaoi.scala
@@ -37,6 +37,7 @@ import squants.Length
 import squants.Time
 import squants.space.Arcseconds
 import squants.time.TimeConversions._
+import cats.Applicative
 
 final case class Gsaoi[F[_]: Logger: Async](
   controller:        GsaoiController[F],
@@ -66,6 +67,8 @@ final case class Gsaoi[F[_]: Logger: Async](
         .widenRethrowT
         .flatMap(x => controller.observe(fileId, x))
     }
+
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 
   override def calcObserveTime(config: CleanConfig): F[Time] =
     readDCConfig(config)

--- a/modules/server/src/main/scala/seqexec/server/nifs/Nifs.scala
+++ b/modules/server/src/main/scala/seqexec/server/nifs/Nifs.scala
@@ -41,6 +41,7 @@ import squants.Length
 import squants.Time
 import squants.space.Arcseconds
 import squants.time.TimeConversions._
+import cats.Applicative
 
 final case class Nifs[F[_]: Logger: Async](
   controller:        NifsController[F],
@@ -66,6 +67,8 @@ final case class Nifs[F[_]: Logger: Async](
         .widenRethrowT
         .flatMap(controller.observe(fileId, _))
     }
+
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 
   override def calcObserveTime(config: CleanConfig): F[Time] =
     getDCConfig(config)

--- a/modules/server/src/main/scala/seqexec/server/niri/Niri.scala
+++ b/modules/server/src/main/scala/seqexec/server/niri/Niri.scala
@@ -44,6 +44,7 @@ import squants.Time
 import squants.space.Arcseconds
 import squants.time.TimeConversions._
 import cats.effect.Async
+import cats.Applicative
 
 final case class Niri[F[_]: Async: Logger](
   controller:        NiriController[F],
@@ -67,6 +68,8 @@ final case class Niri[F[_]: Async: Logger](
         .widenRethrowT
         .flatMap(controller.observe(fileId, _))
     }
+
+  override val sequenceComplete: F[Unit] = Applicative[F].unit
 
   override def calcObserveTime(config: CleanConfig): F[Time] =
     getDCConfig(config)

--- a/modules/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/SeqTranslateSpec.scala
@@ -54,7 +54,8 @@ class SeqTranslateSpec extends TestCommon {
         Set(GmosS),
         _ => InstrumentSystem.Uncontrollable,
         SequenceGen.StepActionsGen(Map.empty,
-                                   (_, _) => List(observeActions(Action.ActionState.Idle))
+                                   (_, _) => List(observeActions(Action.ActionState.Idle)),
+                                   None
         )
       )
     )

--- a/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/SeqexecEngineSpec.scala
@@ -464,7 +464,8 @@ class SeqexecEngineSpec extends TestCommon with Matchers with NonImplicitAsserti
           _ => InstrumentSystem.Uncontrollable,
           generator = SequenceGen.StepActionsGen(
             configs = resources.map(r => r -> { _: SystemOverrides => pendingAction[IO](r) }).toMap,
-            post = (_, _) => Nil
+            post = (_, _) => Nil,
+            None
           )
         )
       }
@@ -853,7 +854,8 @@ class SeqexecEngineSpec extends TestCommon with Matchers with NonImplicitAsserti
           _ => InstrumentSystem.Uncontrollable,
           generator = SequenceGen.StepActionsGen(
             configs = resources.map(r => r -> { _: SystemOverrides => pendingAction[IO](r) }).toMap,
-            post = (_, _) => Nil
+            post = (_, _) => Nil,
+            None
           )
         )
       }

--- a/modules/server/src/test/scala/seqexec/server/TestCommon.scala
+++ b/modules/server/src/test/scala/seqexec/server/TestCommon.scala
@@ -276,7 +276,8 @@ object TestCommon {
         _ => InstrumentSystem.Uncontrollable,
         generator = SequenceGen.StepActionsGen(
           configs = Map(),
-          post = (_, _) => List(NonEmptyList.one(pendingAction[IO](Instrument.F2)))
+          post = (_, _) => List(NonEmptyList.one(pendingAction[IO](Instrument.F2))),
+          None
         )
       )
     )
@@ -297,7 +298,8 @@ object TestCommon {
           _ => InstrumentSystem.Uncontrollable,
           generator = SequenceGen.StepActionsGen(
             configs = Map.empty,
-            post = (_, _) => List(NonEmptyList.one(pendingAction[IO](Instrument.F2)))
+            post = (_, _) => List(NonEmptyList.one(pendingAction[IO](Instrument.F2))),
+            None
           )
         )
       )
@@ -320,7 +322,8 @@ object TestCommon {
         _ => InstrumentSystem.Uncontrollable,
         generator = SequenceGen.StepActionsGen(
           configs = resources.map(r => r -> { _: SystemOverrides => pendingAction[IO](r) }).toMap,
-          post = (_, _) => Nil
+          post = (_, _) => Nil,
+          None
         )
       ),
       SequenceGen.PendingStepGen(
@@ -331,7 +334,8 @@ object TestCommon {
         _ => InstrumentSystem.Uncontrollable,
         generator = SequenceGen.StepActionsGen(
           configs = resources.map(r => r -> { _: SystemOverrides => pendingAction[IO](r) }).toMap,
-          post = (_, _) => Nil
+          post = (_, _) => Nil,
+          None
         )
       )
     )


### PR DESCRIPTION
For IGRINS2 we need a way to inform the instrument when the sequence has been completed

This PR adds a new method for `InstrumentSystem`, `sequenceComplete` which will be called when the last  step gets completed.

In this PR none of  the instrument will use this action but in the near future IGRINS2 will add an implementation