### PR TITLE
[GNFR-73603] Show offsets column whenever there's an Object step in the sequence

### DIFF
--- a/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
+++ b/modules/web/client/src/main/scala/seqexec/web/client/components/sequence/steps/StepsTable.scala
@@ -371,10 +371,8 @@ final case class StepsTable(
     steps.exists(s => s.instrument.displayItems.contains(p))
 
   val showOffsets: Boolean =
-    stepsList.headOption.flatMap(stepTypeO.getOption) match {
-      case Some(StepType.Object) => showProp(InstrumentProperties.Offsets)
-      case _                     => false
-    }
+    showProp(InstrumentProperties.Offsets) &&
+      stepsList.exists(s => stepTypeO.getOption(s).contains(StepType.Object))
 
   val offsetWidth: Option[Double] = {
     val (maxWidth, maxAxisLabelWidth, maxNodLabelWidth) = stepsList.sequenceOffsetMaxWidth


### PR DESCRIPTION
Addresses [GNFR-73603](https://noirlab.atlassian.net/browse/GNFR-73603) / [REL-4430](https://noirlab.atlassian.net/browse/REL-4430).

The offsets column was hidden unless the first step was of type `Object`. This PR changes the logic so that the column is now hidden if there are no `Object` steps at all in the sequence.