### PR TITLE
REL-4609 Use a different connection name for different instances

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         };
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ typelevel-nix.overlay scala-cli-overlay];
+          overlays = [ typelevel-nix.overlays.default scala-cli-overlay];
         };
         pkgs2 = import (fetchTarball {
           url = "https://github.com/NixOS/nixpkgs/archive/6babc092caf5ed6744d5eb49f7d233dbb3c4f1ef.tar.gz";

--- a/modules/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
+++ b/modules/web/server/src/main/scala/seqexec/web/server/http4s/WebServerLauncher.scala
@@ -240,7 +240,13 @@ object WebServerLauncher extends IOApp with LogInitialization {
     ): Resource[IO, SeqexecEngine[IO]] =
       for {
         caS  <- Resource.eval(CaServiceInit.caInit[IO](conf.seqexecEngine))
-        sys  <- Systems.build(conf.site, httpClient, conf.seqexecEngine, caS)
+        sys  <-
+          Systems.build(conf.site,
+                        httpClient,
+                        conf.seqexecEngine,
+                        caS,
+                        conf.webServer.externalBaseUrl
+          )
         seqE <- Resource.eval(SeqexecEngine.build(conf.site, sys, conf.seqexecEngine))
       } yield seqE
 


### PR DESCRIPTION
We need to make the giapi connection name unique.
If we have multiple seqexec instances (production/test) connected at the same time there will be a conflict.

This PR solves it by attaching the seqexec host to the connection name