### PR TITLE
REL-4899 Fixed some issues with LGS+P1 nad LGS+OI control.

### DIFF
--- a/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -39,7 +39,7 @@ object AltairControllerEpics {
     preparedMatrixCoords: (Length, Length),
     strapRTStatus:        Boolean,
     strapTempStatus:      Boolean,
-    stapHVoltStatus:      Boolean,
+    strapHVoltStatus:     Boolean,
     strapLoop:            Boolean,
     sfoLoop:              LgsSfoControl,
     strapGate:            Int,
@@ -255,7 +255,7 @@ object AltairControllerEpics {
           ),
           ()
         ) *>
-        currCfg.stapHVoltStatus.either(
+        currCfg.strapHVoltStatus.either(
           SeqexecFailure.Unexpected("Cannot start Altair STRAP loop, HVolt status is bad."),
           ()
         )
@@ -480,8 +480,8 @@ object AltairControllerEpics {
           case LgsWithP1          =>
             AltairPauseResume(
               guideOff(currCfg.aoLoop && pauseReasons.fixed.contains(P1Off)),
-              GuideCapabilities(!pauseReasons.fixed.contains(P1Off),
-                                canGuideM1 = !pauseReasons.fixed.contains(P1Off)
+              GuideCapabilities(!pauseReasons.fixed.contains(P1Off) && currCfg.aoLoop,
+                                canGuideM1 = !pauseReasons.fixed.contains(P1Off) && currCfg.aoLoop
               ),
               pauseTargetFilter = false,
               (resumeReasons.contains(P1On) && resumeReasons.contains(
@@ -497,8 +497,8 @@ object AltairControllerEpics {
           case LgsWithOi          =>
             AltairPauseResume(
               guideOff(currCfg.aoLoop && pauseReasons.fixed.contains(OiOff)),
-              GuideCapabilities(!pauseReasons.fixed.contains(OiOff),
-                                canGuideM1 = !pauseReasons.fixed.contains(OiOff)
+              GuideCapabilities(!pauseReasons.fixed.contains(OiOff) && currCfg.aoLoop,
+                                canGuideM1 = !pauseReasons.fixed.contains(OiOff) && currCfg.aoLoop
               ),
               pauseTargetFilter = false,
               (resumeReasons.contains(OiOn) && resumeReasons.contains(

--- a/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
+++ b/modules/server/src/main/scala/seqexec/server/altair/AltairControllerEpics.scala
@@ -484,10 +484,8 @@ object AltairControllerEpics {
                                 canGuideM1 = !pauseReasons.fixed.contains(P1Off) && currCfg.aoLoop
               ),
               pauseTargetFilter = false,
-              (resumeReasons.contains(P1On) && resumeReasons.contains(
-                GaosGuideOn
-              ) && (!currCfg.aoLoop || pauseReasons
-                .contains(P1Off))).option(setCorrectionsOn.void),
+              (resumeReasons.contains(P1On) && (!currCfg.aoLoop || pauseReasons.contains(P1Off)))
+                .option(setCorrectionsOn.void),
               GuideCapabilities(resumeReasons.fixed.contains(P1On),
                                 canGuideM1 = resumeReasons.fixed.contains(P1On)
               ),
@@ -501,10 +499,8 @@ object AltairControllerEpics {
                                 canGuideM1 = !pauseReasons.fixed.contains(OiOff) && currCfg.aoLoop
               ),
               pauseTargetFilter = false,
-              (resumeReasons.contains(OiOn) && resumeReasons.contains(
-                GaosGuideOn
-              ) && (!currCfg.aoLoop || pauseReasons
-                .contains(OiOff))).option(setCorrectionsOn.void),
+              (resumeReasons.contains(OiOn) && (!currCfg.aoLoop || pauseReasons.contains(OiOff)))
+                .option(setCorrectionsOn.void),
               GuideCapabilities(resumeReasons.fixed.contains(OiOn),
                                 canGuideM1 = resumeReasons.fixed.contains(OiOn)
               ),

--- a/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
+++ b/modules/server/src/main/scala/seqexec/server/tcs/TcsNorthControllerEpicsAo.scala
@@ -233,6 +233,15 @@ object TcsNorthControllerEpicsAo {
       )
     ).flattenOption
 
+    private def canGuideWhileOffseting(
+      distanceSquared: Option[Area],
+      threshold:       Option[Length]
+    ): Boolean = (distanceSquared, threshold) match {
+      case (None, _)           => true
+      case (Some(_), None)     => false
+      case (Some(d2), Some(t)) => d2 < t * t
+    }
+
     private def calcGuideOffCapabilities(m2Name: TipTiltSource, m1Name: M1Source)(
       tcsGuideCurrent: TelescopeGuideConfig,
       guiderCurrent:   GuiderConfig,
@@ -241,18 +250,17 @@ object TcsNorthControllerEpicsAo {
       distanceSquared: Option[Area],
       threshold:       Option[Length]
     ): GuideCapabilities = {
-      val canGuideWhileOffseting = (distanceSquared, threshold) match {
-        case (None, _)           => true
-        case (Some(_), None)     => false
-        case (Some(d2), Some(t)) => d2 < t * t
-      }
-      val guiderActive           = guiderCurrent.isActive && guiderDemand.isActive
+      val guiderActive: Boolean = guiderCurrent.isActive && guiderDemand.isActive
 
       GuideCapabilities(
-        canGuideWhileOffseting && guiderActive && tcsGuideCurrent.m2Guide.uses(
+        canGuideWhileOffseting(distanceSquared,
+                               threshold
+        ) && guiderActive && tcsGuideCurrent.m2Guide.uses(
           m2Name
         ) && tcsGuideDemand.m2Guide.uses(m2Name),
-        canGuideWhileOffseting && guiderActive && tcsGuideCurrent.m1Guide.uses(
+        canGuideWhileOffseting(distanceSquared,
+                               threshold
+        ) && guiderActive && tcsGuideCurrent.m1Guide.uses(
           m1Name
         ) && tcsGuideDemand.m1Guide.uses(m1Name)
       )
@@ -347,8 +355,14 @@ object TcsNorthControllerEpicsAo {
             (!offsetNear(u, current.base.offset))
               .option(PauseCondition.OffsetMove(current.base.offset, u))
           },
-          (!demand.gds.oiwfs.isActive).option(PauseCondition.OiOff),
-          (!demand.gds.pwfs1.isActive).option(PauseCondition.P1Off),
+          (!demand.gds.oiwfs.isActive || !canGuideWhileOffseting(
+            calcMoveDistanceSquared(current.base, demand.tc),
+            demand.inst.oiOffsetGuideThreshold
+          )).option(PauseCondition.OiOff),
+          (!demand.gds.pwfs1.isActive || !canGuideWhileOffseting(
+            calcMoveDistanceSquared(current.base, demand.tc),
+            pwfs1OffsetThreshold.some
+          )).option(PauseCondition.P1Off),
           (!demand.gds.aoguide.isActive).option(PauseCondition.GaosGuideOff)
         ).flattenOption
       )

--- a/modules/server/src/test/scala/seqexec/server/altair/AltairControllerEpicsSpec.scala
+++ b/modules/server/src/test/scala/seqexec/server/altair/AltairControllerEpicsSpec.scala
@@ -22,6 +22,8 @@ import seqexec.server.tcs.{ Gaos, TestTcsEpics }
 import shapeless.tag
 import squants.space.LengthConversions._
 import squants.space.AngleConversions._
+import seqexec.server.tcs.Gaos.PauseCondition
+import seqexec.server.tcs.Gaos.ResumeCondition
 
 class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
 
@@ -706,6 +708,96 @@ class AltairControllerEpicsSpec extends munit.CatsEffectSuite {
       assert(!r.pauseTargetFilter)
       assert(r.guideWhilePaused.canGuideM2)
       assert(r.guideWhilePaused.canGuideM1)
+    }
+  }
+
+  test("AltairControllerEpics should pause and resume LGS+P1 AO guiding when P1 is paused") {
+    val altairEpics = TestAltairEpics.build[IO](
+      TestAltairEpics.defaultState.copy(
+        aoLoop = true,
+        aoFollow = true,
+        aoSettled = true
+      )
+    )
+
+    val tcsEpics = TestTcsEpics.build[IO](aoGuidedTcs)
+
+    val altairCfg = AltairController.LgsWithP1
+
+    for {
+      ao   <- altairEpics
+      tcs  <- tcsEpics
+      c     = AltairControllerEpics(ao, tcs)
+      r    <- c.pauseResume(
+                Gaos.PauseConditionSet.empty + PauseCondition.P1Off,
+                Gaos.ResumeConditionSet.empty + ResumeCondition.GaosGuideOn + ResumeCondition.P1On,
+                baseOffset,
+                Instrument.Gnirs
+              )(altairCfg)
+      _    <- r.pause.orEmpty
+      ao1  <- ao.outputF
+      tcs1 <- tcs.outputF
+      _    <- ao.out.set(List.empty) *> tcs.out.set(List.empty)
+      _    <- r.resume.orEmpty
+      ao2  <- ao.outputF
+      tcs2 <- tcs.outputF
+    } yield {
+      assert(ao1.isEmpty)
+      assert(tcs1.contains(AoCorrectCmd("OFF", 0)))
+      assert(ao2.isEmpty)
+      assert(tcs2.contains(AoCorrectCmd("ON", 1)))
+      assert(!r.forceFreeze)
+      assert(!r.guideWhilePaused.canGuideM2)
+      assert(!r.guideWhilePaused.canGuideM1)
+      assert(r.restoreOnResume.canGuideM2)
+      assert(r.restoreOnResume.canGuideM1)
+    }
+  }
+
+  test("AltairControllerEpics should resume LGS+P1 AO guiding after a sky") {
+    val altairEpics = TestAltairEpics.build[IO](
+      TestAltairEpics.defaultState.copy(
+        aoLoop = false,
+        aoFollow = false,
+        aoSettled = false
+      )
+    )
+
+    val tcsEpics = TestTcsEpics.build[IO](aoGuidedTcs)
+
+    val altairCfg = AltairController.LgsWithP1
+
+    val offset = FocalPlaneOffset(tag[OffsetX](-30.0.millimeters), tag[OffsetY](-30.0.millimeters))
+
+    for {
+      ao   <- altairEpics
+      tcs  <- tcsEpics
+      c     = AltairControllerEpics(ao, tcs)
+      r    <- c.pauseResume(
+                Gaos.PauseConditionSet.empty + Gaos.PauseCondition.P1Off + Gaos.PauseCondition
+                  .OffsetMove(baseOffset, offset),
+                Gaos.ResumeConditionSet.empty + ResumeCondition.GaosGuideOn + ResumeCondition.P1On + ResumeCondition
+                  .OffsetReached(offset),
+                baseOffset,
+                Instrument.Gnirs
+              )(altairCfg)
+      _    <- r.pause.orEmpty
+      ao1  <- ao.outputF
+      tcs1 <- tcs.outputF
+      _    <- ao.out.set(List.empty) *> tcs.out.set(List.empty)
+      _    <- r.resume.orEmpty
+      ao2  <- ao.outputF
+      tcs2 <- tcs.outputF
+    } yield {
+      assert(ao1.isEmpty)
+      assert(tcs1.isEmpty)
+      assert(ao2.isEmpty)
+      assert(tcs2.contains(AoCorrectCmd("ON", 1)))
+      assert(!r.forceFreeze)
+      assert(!r.guideWhilePaused.canGuideM2)
+      assert(!r.guideWhilePaused.canGuideM1)
+      assert(r.restoreOnResume.canGuideM2)
+      assert(r.restoreOnResume.canGuideM1)
     }
   }
 


### PR DESCRIPTION
Fixed some bugs:
- AltairControllerEpics declared M2 could guide during an offset even if AO loops was off (for example, when coming from an sky)
- TcsNorthControllerEpicsAo was not considering if P1 or OI could keep producing corrections while applying an offset.

Also, added some unit tests for LGS+P1